### PR TITLE
Fix hexdump command used for mercurial dirstate parsing

### DIFF
--- a/Functions/VCS_Info/Backends/VCS_INFO_get_data_hg
+++ b/Functions/VCS_Info/Backends/VCS_INFO_get_data_hg
@@ -42,7 +42,7 @@ if zstyle -t ":vcs_info:${vcs}:${usercontext}:${rrn}" get-revision ; then
     if zstyle -t ":vcs_info:${vcs}:${usercontext}:${rrn}" use-simple \
             && ( VCS_INFO_check_com hexdump ) && [[ -r ${dirstatefile} ]] ; then
         # Calling hexdump is (much) faster than hg but doesn't get the local rev
-        r_csetid=$(hexdump -n 20 -e '1/1 "%02x"' ${dirstatefile})
+        r_csetid=$(hexdump -n 20 -v -e '1/1 "%02x"' ${dirstatefile})
     else
         # Settling for a short (but unique!) hash because getting the full
         # 40-char hash in addition to all the other info we want isn't


### PR DESCRIPTION
Normally, the old commands works.  But very rarely, it outputs a string
like the following instead:
❯ hexdump -n20 -e '1/1 "%02x"' .hg/dirstate
77bba665e970146bd2be0b2da40092e340*
8804

Changing the command resolves the problem:
❯ hexdump -n20 -e '20/1 "%02x"' .hg/dirstate
77bba665e970146bd2be0b2da40092e340408804
