### PR TITLE
Specify system python in dnf completion

### DIFF
--- a/Completion/Redhat/Command/_dnf
+++ b/Completion/Redhat/Command/_dnf
@@ -38,9 +38,9 @@ _dnf_local_packages() {
 
 _dnf() {
   if [[ "$(readlink /usr/bin/dnf)" == "dnf-2" ]]; then
-    local python_exec="python2"
+    local python_exec="/usr/bin/python2"
   else
-    local python_exec="python3"
+    local python_exec="/usr/bin/python3"
   fi
   local helper=$(${python_exec} -c "import dnf.cli; print('{}/completion_helper.py'.format(dnf.cli.__path__[0]))")
   local cache_file="/var/cache/dnf/packages.db"


### PR DESCRIPTION
The python executable in the python_exec variable was the python[2|3]
executable found in $PATH. When the python[2|3] executable was not the
system installed version the completion command raised an `ImportError`
as the 'dnf' module was not found.

This commit just completely specifies the python version to be the
system version `/usr/bin/python[2|3]`, allowing completion within a
python dev environment.