### PR TITLE
remove trailing whitespace

### DIFF
--- a/Src/Builtins/rlimits.c
+++ b/Src/Builtins/rlimits.c
@@ -76,7 +76,7 @@ zstrtorlimt(const char *s, char **t, int base)
 	    base = 16, s++;
 	else
 	    base = 8;
-    } 
+    }
     if (base <= 10)
 	for (; *s >= '0' && *s < ('0' + base); s++)
 	    ret = ret * base + *s - '0';

--- a/Src/Modules/curses.c
+++ b/Src/Modules/curses.c
@@ -349,7 +349,7 @@ zcurses_colorget(const char *nam, char *colorpair)
 	    return NULL;
 	}
 
-	*bg = '\0';        
+	*bg = '\0';
 
         // cp/bg can be {number}/{number} or {name}/{name}
 
@@ -383,7 +383,7 @@ zcurses_colorget(const char *nam, char *colorpair)
 	}
 
 	cpn = (Colorpairnode)zshcalloc(sizeof(struct colorpairnode));
-	
+
 	if (!cpn) {
 	    zsfree(cp);
 	    return NULL;

--- a/Src/Modules/db_gdbm.c
+++ b/Src/Modules/db_gdbm.c
@@ -173,7 +173,7 @@ bin_ztie(char *nam, char **args, Options ops, UNUSED(int func))
 
     tied_param->gsu.h = &gdbm_hash_gsu;
 
-    /* Allocate parameter sub-gsu, fill dbf field. 
+    /* Allocate parameter sub-gsu, fill dbf field.
      * dbf allocation is 1 to 1 accompanied by
      * gsu_scalar_ext allocation. */
 
@@ -534,7 +534,7 @@ gdbmhashsetfn(Param pm, HashTable ht)
             /* Store */
 	    content.dptr = umval;
 	    content.dsize = umlen;
-	    (void)gdbm_store(dbf, key, content, GDBM_REPLACE);	
+	    (void)gdbm_store(dbf, key, content, GDBM_REPLACE);
 
             /* Free - unmetafy_zalloc allocates
              * exact required space + 1 null byte */

--- a/Src/Modules/files.c
+++ b/Src/Modules/files.c
@@ -612,7 +612,7 @@ bin_rm(char *nam, char **args, Options ops, UNUSED(int func))
     rmm.opt_force = OPT_ISSET(ops,'f');
     rmm.opt_interact = OPT_ISSET(ops,'i') && !OPT_ISSET(ops,'f');
     rmm.opt_unlinkdir = OPT_ISSET(ops,'d');
-    err = recursivecmd(nam, OPT_ISSET(ops,'f'), 
+    err = recursivecmd(nam, OPT_ISSET(ops,'f'),
 		       OPT_ISSET(ops,'r') && !OPT_ISSET(ops,'d'),
 		       OPT_ISSET(ops,'s'),
 	args, recurse_donothing, rm_dirpost, rm_leaf, &rmm);

--- a/Src/Modules/langinfo.c
+++ b/Src/Modules/langinfo.c
@@ -445,7 +445,7 @@ scanlanginfo(UNUSED(HashTable ht), ScanFunc func, int flags)
 	    func(&pm->node, flags);
 	}
     }
-    
+
 }
 
 static struct paramdef partab[] = {

--- a/Src/Modules/mapfile.c
+++ b/Src/Modules/mapfile.c
@@ -24,7 +24,7 @@
  * The softwareprovided hereunder is on an "as is" basis, and Peter
  * Stephenson, Sven Wischnowsky and the Zsh Development Group have no
  * obligation to provide maintenance, support, updates, enhancements, or
- * modifications. 
+ * modifications.
  *
  */
 

--- a/Src/Modules/mathfunc.c
+++ b/Src/Modules/mathfunc.c
@@ -215,7 +215,7 @@ math_func(char *name, int argc, mnumber *argv, int id)
       case BF_POS:
 	  rtst = (argd <= 0.0);
 	  break;
-	  
+
       case BF_NONNEG:
 	  rtst = (argd < 0.0);
 	  break;
@@ -358,7 +358,7 @@ math_func(char *name, int argc, mnumber *argv, int id)
 
   case MF_ILOGB:
       ret.type = MN_INTEGER;
-      ret.u.l = ilogb(argd); 
+      ret.u.l = ilogb(argd);
       break;
 
   case MF_INT:
@@ -399,7 +399,7 @@ math_func(char *name, int argc, mnumber *argv, int id)
       break;
 
   case MF_LOGB:
-      retd = logb(argd); 
+      retd = logb(argd);
       break;
 
   case MF_NEXTAFTER:

--- a/Src/Modules/param_private.c
+++ b/Src/Modules/param_private.c
@@ -626,7 +626,7 @@ cleanup_(Module m)
     *(Builtin)hn = save_local;
 
     removehashnode(reswdtab, "private");
-    
+
     realparamtab->getnode = getparamnode;
     realparamtab->getnode2 = save_getnode2;
     realparamtab->printnode = save_printnode;

--- a/Src/Modules/parameter.c
+++ b/Src/Modules/parameter.c
@@ -1930,7 +1930,7 @@ static HashNode
 getpmdissalias(HashTable ht, const char *name)
 {
     return getalias(sufaliastab, ht, name, ALIAS_SUFFIX|DISABLED);
-} 
+}
 
 /**/
 static void
@@ -2201,7 +2201,7 @@ static struct paramdef partab[] = {
 	    &pmdisraliases_gsu, getpmdisralias, scanpmdisraliases),
     SPECIALPMDEF("dis_builtins", PM_READONLY,
 	    NULL, getpmdisbuiltin, scanpmdisbuiltins),
-    SPECIALPMDEF("dis_functions", 0, 
+    SPECIALPMDEF("dis_functions", 0,
 	    &pmdisfunctions_gsu, getpmdisfunction, scanpmdisfunctions),
     SPECIALPMDEF("dis_functions_source", PM_READONLY, NULL,
 		 getpmdisfunction_source, scanpmdisfunction_source),

--- a/Src/Modules/pcre.c
+++ b/Src/Modules/pcre.c
@@ -78,13 +78,13 @@ bin_pcre_compile(char *nam, char **args, Options ops, UNUSED(int func))
     int pcre_opts = 0, pcre_errptr, target_len;
     const char *pcre_error;
     char *target;
-    
+
     if(OPT_ISSET(ops,'a')) pcre_opts |= PCRE_ANCHORED;
     if(OPT_ISSET(ops,'i')) pcre_opts |= PCRE_CASELESS;
     if(OPT_ISSET(ops,'m')) pcre_opts |= PCRE_MULTILINE;
     if(OPT_ISSET(ops,'x')) pcre_opts |= PCRE_EXTENDED;
     if(OPT_ISSET(ops,'s')) pcre_opts |= PCRE_DOTALL;
-    
+
     if (zpcre_utf8_enabled())
 	pcre_opts |= PCRE_UTF8;
 
@@ -118,7 +118,7 @@ bin_pcre_compile(char *nam, char **args, Options ops, UNUSED(int func))
 	zwarnnam(nam, "error in regex: %s", pcre_error);
 	return 1;
     }
-    
+
     return 0;
 }
 
@@ -136,7 +136,7 @@ bin_pcre_study(char *nam, UNUSED(char **args), UNUSED(Options ops), UNUSED(int f
 	zwarnnam(nam, "no pattern has been compiled for study");
 	return 1;
     }
-    
+
     if (pcre_hints)
 #ifdef PCRE_CONFIG_JIT
 	pcre_free_study(pcre_hints);
@@ -151,7 +151,7 @@ bin_pcre_study(char *nam, UNUSED(char **args), UNUSED(Options ops), UNUSED(int f
 	zwarnnam(nam, "error while studying regex: %s", pcre_error);
 	return 1;
     }
-    
+
     return 0;
 }
 
@@ -377,7 +377,7 @@ bin_pcre_match(char *nam, char **args, Options ops, UNUSED(int func))
     else {
 	zwarnnam(nam, "error in pcre_exec [%d]", ret);
     }
-    
+
     if (ovec)
 	zfree(ovec, ovecsize*sizeof(int));
 

--- a/Src/Modules/socket.c
+++ b/Src/Modules/socket.c
@@ -174,21 +174,21 @@ bin_zsocket(char *nam, char **args, Options ops, UNUSED(int func))
 	    fd_set rfds;
 	    struct timeval tv;
 	    int ret;
-	    
+
 	    FD_ZERO(&rfds);
 	    FD_SET(lfd, &rfds);
 	    tv.tv_sec = 0;
 	    tv.tv_usec = 0;
-	    
+
 	    if ((ret = select(lfd+1, &rfds, NULL, NULL, &tv)) == 0) return 1;
 	    else if (ret == -1)
 	    {
 		zwarnnam(nam, "select error: %e", errno);
 		return 1;
 	    }
-	    
+
 # endif
-	    
+
 #else
 	    zwarnnam(nam, "not currently supported");
 	    return 1;
@@ -241,7 +241,7 @@ bin_zsocket(char *nam, char **args, Options ops, UNUSED(int func))
 
 	soun.sun_family = AF_UNIX;
 	strncpy(soun.sun_path, args[0], sizeof(soun.sun_path)-1);
-	
+
 	if ((err = connect(sfd, (struct sockaddr *)&soun, sizeof(struct sockaddr_un)))) {
 	    zwarnnam(nam, "connection failed: %e", errno);
 	    close(sfd);
@@ -266,7 +266,7 @@ bin_zsocket(char *nam, char **args, Options ops, UNUSED(int func))
 	    if (verbose)
 		printf("%s is now on fd %d\n", soun.sun_path, sfd);
 	}
-	
+
     }
 
     return 0;

--- a/Src/Modules/stat.c
+++ b/Src/Modules/stat.c
@@ -348,7 +348,7 @@ statprint(struct stat *sbuf, char *outbuf, char *fname, int iwhich, int flags)
  *  +type selects just element type of stat buffer (-l gives list):
  *        type can be shortened to unambiguous string.  only one type is
  *        allowed.  The extra type, +link, reads the target of a symbolic
- *        link; it is empty if the stat was not an lstat or if 
+ *        link; it is empty if the stat was not an lstat or if
  *        a file descriptor was stat'd, if the stat'd file is
  *        not a symbolic link, or if symbolic links are not
  *        supported.  If +link is explicitly requested, the -L (lstat)

--- a/Src/Modules/tcp.c
+++ b/Src/Modules/tcp.c
@@ -70,11 +70,11 @@ int h_errno;
 /**/
 mod_export char const *
 zsh_inet_ntop(int af, void const *cp, char *buf, size_t len)
-{       
+{
     if (af != AF_INET) {
 	errno = EAFNOSUPPORT;
 	return NULL;
-    } 
+    }
     if (len < INET_ADDRSTRLEN) {
 	errno = ENOSPC;
 	return NULL;
@@ -271,11 +271,11 @@ static Tcp_session
 zts_byfd(int fd)
 {
     LinkNode node;
-    
+
     for (node = firstnode(ztcp_sessions); node; incnode(node))
 	if (((Tcp_session)getdata(node))->fd == fd)
 	    return (Tcp_session)getdata(node);
-    
+
     return NULL;
 }
 
@@ -295,9 +295,9 @@ mod_export int
 tcp_close(Tcp_session sess)
 {
     int err;
-    
+
     if (sess)
-    {  
+    {
 	if (sess->fd != -1)
 	{
 	    err = zclose(sess->fd);
@@ -516,21 +516,21 @@ bin_ztcp(char *nam, char **args, Options ops, UNUSED(int func))
 	    fd_set rfds;
 	    struct timeval tv;
 	    int ret;
-	    
+
 	    FD_ZERO(&rfds);
 	    FD_SET(lfd, &rfds);
 	    tv.tv_sec = 0;
 	    tv.tv_usec = 0;
-	    
+
 	    if ((ret = select(lfd+1, &rfds, NULL, NULL, &tv)) == 0) return 1;
 	    else if (ret == -1)
 	    {
 		zwarnnam(nam, "select error: %e", errno);
 		return 1;
 	    }
-	    
+
 # endif
-	    
+
 #else
 	    zwarnnam(nam, "not currently supported");
 	    return 1;
@@ -626,16 +626,16 @@ bin_ztcp(char *nam, char **args, Options ops, UNUSED(int func))
 	    else
 		destport = htons(atoi(args[1]));
 	}
-	
+
 	desthost = ztrdup(args[0]);
-	
+
 	zthost = zsh_getipnodebyname(desthost, AF_INET, 0, &herrno);
 	if (!zthost || errflag) {
 	    zwarnnam(nam, "host resolution failure: %s", desthost);
 	    zsfree(desthost);
 	    return 1;
 	}
-	
+
 	sess = tcp_socket(PF_INET, SOCK_STREAM, 0, 0);
 
 	if (!sess) {
@@ -655,7 +655,7 @@ bin_ztcp(char *nam, char **args, Options ops, UNUSED(int func))
 	    zts_delete(sess);
 	    return 1;
 	}
-	
+
 	for (addrp = zthost->h_addr_list; err && *addrp; addrp++) {
 	    if (zthost->h_length != 4)
 		zwarnnam(nam, "address length mismatch");
@@ -663,7 +663,7 @@ bin_ztcp(char *nam, char **args, Options ops, UNUSED(int func))
 		err = tcp_connect(sess, *addrp, zthost, destport);
 	    } while (err && errno == EINTR && !errflag);
 	}
-	
+
 	if (err) {
 	    zwarnnam(nam, "connection failed: %e", errno);
 	    tcp_close(sess);
@@ -688,7 +688,7 @@ bin_ztcp(char *nam, char **args, Options ops, UNUSED(int func))
 		printf("%s:%d is now on fd %d\n",
 			desthost, destport, sess->fd);
 	}
-	
+
 	zsfree(desthost);
     }
 

--- a/Src/Modules/termcap.c
+++ b/Src/Modules/termcap.c
@@ -153,7 +153,7 @@ gettermcap(UNUSED(HashTable ht), const char *name)
     if ((termflags & TERM_UNKNOWN) && (isset(INTERACTIVE) || !init_term()))
 	return NULL;
 
-    
+
     nameu = dupstring(name);
     unmetafy(nameu, &len);
 

--- a/Src/Modules/terminfo.c
+++ b/Src/Modules/terminfo.c
@@ -187,7 +187,7 @@ scanterminfo(UNUSED(HashTable ht), ScanFunc func, int flags)
 	"da", "db", "mir", "msgr", "nxon", "xsb", "npc", "ndscr", "nrrmc",
 	"os", "mc5i", "xvpa", "sam", "eslok", "hz", "ul", "xon", NULL};
 #endif
-    
+
 #ifndef HAVE_NUMNAMES
     static char *numnames[] = {
 	"cols", "it", "lh", "lw", "lines", "lm", "xmc", "ma", "colors",

--- a/Src/Modules/zftp.c
+++ b/Src/Modules/zftp.c
@@ -667,7 +667,7 @@ zfgetline(char *ln, int lnsize, int tmout)
 	    }
 	    break;
 	}
-	
+
 	if (zcfinish)
 	    break;
 	if (added < lnsize) {
@@ -698,7 +698,7 @@ zfgetline(char *ln, int lnsize, int tmout)
  */
 
 /**/
-static int 
+static int
 zfgetmsg(void)
 {
     char line[256], *ptr, *verbose;
@@ -1125,7 +1125,7 @@ zfgetdata(char *name, char *rest, char *cmd, int getsize)
 
 	/* accept the connection */
 	len = sizeof(zdsock);
-	newfd = zfmovefd(accept(zfsess->dfd, (struct sockaddr *)&zdsock, 
+	newfd = zfmovefd(accept(zfsess->dfd, (struct sockaddr *)&zdsock,
 				&len));
 	if (newfd < 0)
 	    zwarnnam(name, "unable to accept data: %e", errno);
@@ -1680,7 +1680,7 @@ zfsenddata(char *name, int recv, int progress, off_t startat)
 
 	noholdintr();
     }
-	
+
     if (toasc)
 	zfree(ascbuf, ZF_ASCSIZE);
     zfclosedata();
@@ -1778,14 +1778,14 @@ zftp_open(char *name, char **args, int flags)
 
     /*
      * This sets an alarm for the whole process, getting the host name
-     * as well as connecting.  Arguably you could time them out separately. 
+     * as well as connecting.  Arguably you could time them out separately.
      */
     tmout = getiparam("ZFTP_TMOUT");
     if (setjmp(zfalrmbuf)) {
 	char *hname;
 	alarm(0);
 	queue_signals();
-	if ((hname = getsparam_u("ZFTP_HOST")) && *hname) 
+	if ((hname = getsparam_u("ZFTP_HOST")) && *hname)
 	    zwarnnam(name, "timeout connecting to %s", hname);
 	else
 	    zwarnnam(name, "timeout on host name lookup");
@@ -1812,7 +1812,7 @@ zftp_open(char *name, char **args, int flags)
 	    /* should use herror() here if available, but maybe
 	     * needs configure test. on AIX it's present but not
 	     * in headers.
-	     * 
+	     *
 	     * on the other hand, herror() is obsolete
 	     */
 	    FAILED();
@@ -2381,7 +2381,7 @@ zfgetcwd(void)
     if (*ptr == '"') {
 	ptr++;
 	endc = '"';
-    } else 
+    } else
 	endc = ' ';
     for (eptr = ptr; *eptr && *eptr != endc; eptr++)
 	;
@@ -2453,7 +2453,7 @@ zftp_type(char *name, char **args, int flags)
 	    zwarnnam(name, "transfer type %s not recognised", str);
 	    return 1;
 	}
-	
+
 	if (nt == 'B')		/* binary = image */
 	    nt = 'I';
     }
@@ -2537,7 +2537,7 @@ zftp_local(UNUSED(char *name), char **args, int flags)
  * Get sends all files to stdout, i.e. this is basically cat. It's up to a
  * shell function driver to turn this into standard FTP-like commands.
  *
- * Put/append sends everything from stdin down the drai^H^H^Hata connection. 
+ * Put/append sends everything from stdin down the drai^H^H^Hata connection.
  * Slightly weird with multiple files in that it tries to read
  * a separate complete file from stdin each time, which is
  * only even potentially useful interactively.  But the only
@@ -3070,7 +3070,7 @@ bin_zftp(char *name, char **args, UNUSED(Options ops), UNUSED(int func))
 	    /*
 	     * with ret == 2, we just got dumped out in the test,
 	     * so enough messages already.
-	     */	       
+	     */
 	    zwarnnam(fullname, "not connected.");
 	}
 	return 1;
@@ -3209,7 +3209,7 @@ boot_(UNUSED(Module m))
     zfsetparam("ZFTP_PREFS", ztrdup("PS"), ZFPM_IFUNSET);
     /* default preferences if user deletes variable */
     zfprefs = ZFPF_SNDP|ZFPF_PASV;
-    
+
     zfsessions = znewlinklist();
     newsession("default");
 

--- a/Src/Modules/zpty.c
+++ b/Src/Modules/zpty.c
@@ -832,7 +832,7 @@ bin_zpty(char *nam, char **args, Options ops, UNUSED(int func))
 	    zwarnnam(nam, "pty command name already used: %s", *args);
 	    return 1;
 	}
-	return newptycmd(nam, *args, args + 1, OPT_ISSET(ops,'e'), 
+	return newptycmd(nam, *args, args + 1, OPT_ISSET(ops,'e'),
 			 OPT_ISSET(ops,'b'));
     } else {
 	Ptycmd p;

--- a/Src/Modules/zselect.c
+++ b/Src/Modules/zselect.c
@@ -204,7 +204,7 @@ bin_zselect(char *nam, char **args, UNUSED(Options ops), UNUSED(int func))
 		    int found = 0;
 
 		    convbase(buf, fd, 10);
-		    for (nptr = firstnode(fdlist); nptr; 
+		    for (nptr = firstnode(fdlist); nptr;
 			 nptr = nextnode(nextnode(nptr))) {
 			if (!strcmp((char *)getdata(nptr), buf)) {
 			    /* Already there, add new character. */

--- a/Src/Modules/zutil.c
+++ b/Src/Modules/zutil.c
@@ -1722,7 +1722,7 @@ bin_zparseopts(char *nam, char **args, UNUSED(Options ops), UNUSED(int func))
 		    zwarnnam(nam, "associative array given more than once");
 		    return 1;
 		}
-		if (o[2]) 
+		if (o[2])
 		    assoc = o + 2;
 		else if (*args)
 		    assoc = *args++;

--- a/Src/Zle/compcore.c
+++ b/Src/Zle/compcore.c
@@ -125,7 +125,7 @@ mod_export LinkList matches;
 /**/
 LinkList fmatches;
 
-/* This holds the list of matches-groups. lastmatches holds the last list of 
+/* This holds the list of matches-groups. lastmatches holds the last list of
  * permanently allocated matches, pmatches is the same for the list
  * currently built, amatches is the heap allocated stuff during completion
  * (after all matches have been generated it is an alias for pmatches), and
@@ -278,7 +278,7 @@ mod_export int lastend;
 #define inststr(X) inststrlen((X),1,-1)
 
 /*
- * Main completion entry point, called from zle. 
+ * Main completion entry point, called from zle.
  * At this point the line is already metafied.
  */
 
@@ -313,7 +313,7 @@ do_completion(UNUSED(Hookdef dummy), Compldat dat)
     zsfree(compexactstr);
     compexactstr = ztrdup("");
     uselist = (useline ?
-	       ((isset(AUTOLIST) && !isset(BASHAUTOLIST)) ? 
+	       ((isset(AUTOLIST) && !isset(BASHAUTOLIST)) ?
 		(isset(LISTAMBIGUOUS) ? 3 : 2) : 0) : 1);
     zsfree(comppatmatch);
     opm = comppatmatch = ztrdup(useglob ? "*" : "");
@@ -703,7 +703,7 @@ callcompfunc(char *s, char *fn)
 	    compsuffix = ztrdup("");
 	} else {
 	    char *ss, sav;
-	    
+
 	    ss = s + offs;
 
 	    sav = *ss;
@@ -1122,7 +1122,7 @@ check_param(char *s, int set, int test)
      *
      * TODO: passing s as a parameter while we get some mysterious
      * offset "offs" into it via a global sucks badly.
-     */ 
+     */
     for (p = s + offs; ; p--) {
 	if (*p == String || *p == Qstring) {
 	    /*
@@ -1869,7 +1869,7 @@ set_comp_sep(void)
 	    compsuffix = ztrdup("");
 	} else {
 	    char *ss, sav;
-	    
+
 	    ss = ns + soffs;
 
 	    sav = *ss;
@@ -1883,7 +1883,7 @@ set_comp_sep(void)
         if ((i = strlen(compprefix)) > 1 && compprefix[i - 1] == '\\' &&
 	    compprefix[i - 2] != '\\' && compprefix[i - 2] != Meta)
             compprefix[i - 1] = '\0';
-        
+
 	tmp = tricat(compqiprefix, compiprefix, multiquote(qp, 1));
 	zsfree(compqiprefix);
 	compqiprefix = tmp;
@@ -3049,7 +3049,7 @@ begcmgroup(char *n, int flags)
     mgroup->heap_id = last_heap_id;
 #endif
     mgroup->name = dupstring(n);
-    mgroup->lcount = mgroup->llcount = mgroup->mcount = mgroup->ecount = 
+    mgroup->lcount = mgroup->llcount = mgroup->mcount = mgroup->ecount =
 	mgroup->ccount = 0;
     mgroup->flags = flags;
     mgroup->matches = NULL;

--- a/Src/Zle/compctl.c
+++ b/Src/Zle/compctl.c
@@ -36,12 +36,12 @@
 static Cmlist cmatcher;
 
 /* Default completion infos */
- 
+
 /**/
 struct compctl cc_compos, cc_default, cc_first, cc_dummy;
- 
+
 /* Hash table for completion info for commands */
- 
+
 /**/
 HashTable compctltab;
 
@@ -379,7 +379,7 @@ get_compctl(char *name, char ***av, Compctl cc, int first, int isdef, int cl)
     /* Parse the basic flags for completion:
      * first is a flag that we are not in extended completion,
      * while hx indicates or (+) completion (need to know for
-     * default and command completion as the initial compctl is special). 
+     * default and command completion as the initial compctl is special).
      * cct is a temporary just to hold flags; it never needs freeing.
      */
     struct compctl cct;
@@ -1802,7 +1802,7 @@ ccmakehookfn(UNUSED(Hookdef dummy), struct ccmakedat *dat)
 	    mstack = &ms;
 
 	    /* Store the matchers used in the bmatchers list which is used
-	     * when building new parts for the string to insert into the 
+	     * when building new parts for the string to insert into the
 	     * line. */
 	    add_bmatchers(m->matcher);
 	} else
@@ -2041,9 +2041,9 @@ addmatch(char *s, char *t)
     }
     if (!ms)
 	return;
-    add_match_data(isalt, ms, s, lc, ipre, ripre, isuf, 
+    add_match_data(isalt, ms, s, lc, ipre, ripre, isuf,
 		   (incompfunc ? dupstring(curcc->prefix) : curcc->prefix),
-		   prpre, 
+		   prpre,
 		   (isfile ? lppre : NULL), NULL,
 		   (isfile ? lpsuf : NULL), NULL,
 		   (incompfunc ? dupstring(curcc->suffix) : curcc->suffix),
@@ -2709,7 +2709,7 @@ makecomplistext(Compctl occ, char *os, int incmd)
 				compadd = a, t = 1;
 			}
 			break;
-			
+
 		    case CCT_CURPAT:
 		    case CCT_CURSTR:
 			tt = clwpos;
@@ -2723,7 +2723,7 @@ makecomplistext(Compctl occ, char *os, int incmd)
 			s = ztrdup((a < 0 || a >= clwnum) ? "" :
 				   clwords[a]);
 			untokenize(s);
-			
+
 			if (cc->type == CCT_CURPAT ||
 			    cc->type == CCT_WORDPAT) {
 			    tokenize(ss = dupstring(cc->u.s.s[i]));
@@ -3065,7 +3065,7 @@ makecomplistflags(Compctl cc, char *s, int incmd, int compadd)
     usemenu = um;
     patcomp = filecomp = NULL;
     rpre = rsuf = lpre = lsuf = ppre = psuf = lppre = lpsuf =
-	fpre = fsuf = ipre = ripre = prpre = 
+	fpre = fsuf = ipre = ripre = prpre =
 	qfpre = qfsuf = qrpre = qrsuf = qlpre = qlsuf = NULL;
 
     curcc = cc;
@@ -3669,15 +3669,15 @@ makecomplistflags(Compctl cc, char *s, int incmd, int compadd)
 	Shfunc shfunc;
 	char **r;
 	int lv = lastval;
-	    
+
 	/* Get the function. */
 	if ((shfunc = getshfunc(cc->func))) {
 	    /* We have it, so build a argument list. */
 	    LinkList args = newlinklist();
 	    int osc = sfcontext;
-		
+
 	    addlinknode(args, cc->func);
-		
+
 	    if (delit) {
 		p = dupstrpfx(os, ooffs);
 		untokenize(p);
@@ -3689,7 +3689,7 @@ makecomplistflags(Compctl cc, char *s, int incmd, int compadd)
 		addlinknode(args, lpre);
 		addlinknode(args, lsuf);
 	    }
-		
+
 	    /* This flag allows us to use read -l and -c. */
 	    if (incompfunc != 1)
 		incompctlfunc = 1;
@@ -3912,9 +3912,9 @@ makecomplistflags(Compctl cc, char *s, int incmd, int compadd)
 	char **ow = clwords, *os = cmdstr, *ops = NULL;
 	int oldn = clwnum, oldp = clwpos, br;
 	unsigned long occ = ccont;
-	
+
 	ccont = CC_CCCONT;
-	
+
 	/* So we restrict the words-array. */
 	if (brange >= clwnum)
 	    brange = clwnum - 1;

--- a/Src/Zle/complete.c
+++ b/Src/Zle/complete.c
@@ -83,7 +83,7 @@ char *compiprefix,
 /**/
 Param *comprpms;
 
-/* 
+/*
  * An array of Param structures for elemens of $compstate; see
  * 'compkparams' below.
  *
@@ -227,7 +227,7 @@ cpcpattern(Cpattern o)
     return r;
 }
 
-/* 
+/*
  * Parse a string for matcher control, containing multiple matchers.
  *
  * 's' is the string to be parsed.
@@ -403,7 +403,7 @@ parse_cmatcher(char *name, char *s)
 }
 
 /*
- * Parse a pattern for matcher control. 
+ * Parse a pattern for matcher control.
  * name is the name of the builtin from which this is called, for errors.
  * *sp is the input string and will be updated to the end of the parsed
  *   pattern.
@@ -572,7 +572,7 @@ bin_compadd(char *name, char **argv, UNUSED(Options ops), UNUSED(int func))
 	return 1;
     }
     dat.ipre = dat.isuf = dat.ppre = dat.psuf = dat.prpre = dat.mesg =
-	dat.pre = dat.suf = dat.group = dat.rems = dat.remf = dat.disp = 
+	dat.pre = dat.suf = dat.group = dat.rems = dat.remf = dat.disp =
 	dat.ign = dat.exp = dat.apar = dat.opar = dat.dpar = NULL;
     dat.match = NULL;
     dat.flags = 0;
@@ -1497,7 +1497,7 @@ comp_wrapper(Eprog prog, FuncWrap w, char *name)
 	unsigned int runset = 0, kunset = 0, m, sm;
 	Param *pp;
 
-	m = CP_WORDS | CP_REDIRS | CP_CURRENT | CP_PREFIX | CP_SUFFIX | 
+	m = CP_WORDS | CP_REDIRS | CP_CURRENT | CP_PREFIX | CP_SUFFIX |
 	    CP_IPREFIX | CP_ISUFFIX | CP_QIPREFIX | CP_QISUFFIX;
 	for (pp = comprpms, sm = 1; m; pp++, m >>= 1, sm <<= 1) {
 	    if ((m & 1) && ((*pp)->node.flags & PM_UNSET))
@@ -1656,7 +1656,7 @@ setup_(UNUSED(Module m))
 
     comprpms = compkpms = NULL;
     compwords = compredirs = NULL;
-    compprefix = compsuffix = compiprefix = compisuffix = 
+    compprefix = compsuffix = compiprefix = compisuffix =
 	compqiprefix = compqisuffix =
 	compcontext = compparameter = compredirect = compquote =
 	compquoting = comprestore = complist = compinsert =

--- a/Src/Zle/complist.c
+++ b/Src/Zle/complist.c
@@ -45,7 +45,7 @@
  *           horizontally this applies both the screen and the logical array.
  * mline:    The line for the selected completion in the logical array of
  *           all matches, not all of which may be on screen at once.
- * mcols:    Local copy of columns used in sizing arrays. 
+ * mcols:    Local copy of columns used in sizing arrays.
  * mlines:   The number of lines in the logical array of all matches,
  *           initialised from listdat.nlines.
  */
@@ -204,7 +204,7 @@ static char *colnames[] = {
 
 static char *defcols[] = {
     "0", "0", "1;31", "1;36", "33", "1;35", "1;33", "1;33", NULL, NULL,
-    "37;41", "30;43", "30;42", "34;42", "37;44", "1;32", 
+    "37;41", "30;43", "30;42", "34;42", "37;44", "1;32",
     "\033[", "m", NULL, "0", "0", "7", NULL, NULL, "0"
 };
 
@@ -516,7 +516,7 @@ getcols(void)
 	    mcolors.files[i] = filecol("");
 	mcolors.pats = NULL;
 	mcolors.exts = NULL;
-	
+
 	if ((s = tcstr[TCSTANDOUTBEG]) && s[0]) {
 	    mcolors.files[COL_MA] = filecol(s);
 	    mcolors.files[COL_EC] = filecol(tcstr[TCSTANDOUTEND]);
@@ -633,19 +633,19 @@ doiscol(int pos)
 	    zlrputs(curiscols[--curiscol]);
 	}
     }
-    while (((fi = (endpos[curisbeg] < begpos[curisbeg] || 
+    while (((fi = (endpos[curisbeg] < begpos[curisbeg] ||
 		  begpos[curisbeg] == -1)) ||
 	    pos == begpos[curisbeg]) && *patcols) {
 	if (!fi) {
 	    int i, j, e = endpos[curisbeg];
-	    
+
 	    /* insert e in sendpos */
 	    for (i = curissend; sendpos[i] <= e; ++i)
 		;
 	    for (j = MAX_POS - 1; j > i; --j)
 		sendpos[j] = sendpos[j-1];
 	    sendpos[i] = e;
-	    
+
 	    zcputs(NULL, COL_NO);
 	    zlrputs(*patcols);
 	    curiscols[++curiscol] = *patcols;
@@ -2137,7 +2137,7 @@ adjust_mcol(int wish, Cmatch ***tabp, Cmgroup **grp)
 	*grp = *grp + c - mcol;
 
     mcol = c;
-    
+
     return 0;
 }
 
@@ -2414,7 +2414,7 @@ domenuselect(Hookdef dummy, Chdata dat)
 	wasmeta = 0;
 	metafy_line();
     }
-    
+
     if ((s = getsparam("MENUSCROLL"))) {
 	if (!(step = mathevali(s)))
 	    step = (zterm_lines - nlnct) >> 1;
@@ -2951,7 +2951,7 @@ domenuselect(Hookdef dummy, Chdata dat)
 	    do {
 		if (mline == mlines - 1) {
 		    if (wrap & 2) {
-			mline = omline; 
+			mline = omline;
 			p = op;
 			break;
 		    }
@@ -2986,7 +2986,7 @@ domenuselect(Hookdef dummy, Chdata dat)
 	    do {
 		if (!mline) {
 		    if (wrap & 2) {
-			mline = omline; 
+			mline = omline;
 			p = op;
 			break;
 		    }

--- a/Src/Zle/compmatch.c
+++ b/Src/Zle/compmatch.c
@@ -319,14 +319,14 @@ abort_match(void)
 /* This adds a new string in the static char buffer. The arguments are
  * the matcher used (if any), the strings from the line and the word
  * and the length of the string from the word. The last argument is
- * non-zero if we are matching a suffix (where the given string has to 
+ * non-zero if we are matching a suffix (where the given string has to
  * be prepended to the contents of the buffer). */
 
 /**/
 static void
 add_match_str(Cmatcher m, char *l, char *w, int wl, int sfx)
 {
-    /* Get the string and length to insert: either from the line 
+    /* Get the string and length to insert: either from the line
      * or from the match. */
     if (m && (m->flags & CMF_LINE)) {
 	wl = m->llen; w = l;
@@ -365,7 +365,7 @@ add_match_str(Cmatcher m, char *l, char *w, int wl, int sfx)
  * matcher used, pointers to the line and word strings for the anchor,
  * a pointer to the original line string for the whole part, the string
  * before (or after) the anchor that has not yet been added, the length
- * of the line-string for that, and a flag saying if we are matching a 
+ * of the line-string for that, and a flag saying if we are matching a
  * suffix. */
 
 /**/
@@ -607,7 +607,7 @@ match_str(char *l, char *w, Brinfo *bpp, int bc, int *rwlp,
 		     * block.
 		     */
 		    int t;
-		    /* 
+		    /*
 		     * 1 iff the anchor and the word are on the same side of
 		     * the line pattern; that is: if either
 		     * - the anchor is on the left and we are matching
@@ -660,7 +660,7 @@ match_str(char *l, char *w, Brinfo *bpp, int bc, int *rwlp,
 		     * Contact zsh-workers@zsh.org.
 		     */
 		    char *tp;
-		    /* 
+		    /*
 		     * Temporary variable.  Used as temporary storage for a
 		     *
 		     *     {
@@ -779,7 +779,7 @@ match_str(char *l, char *w, Brinfo *bpp, int bc, int *rwlp,
 		    if (!t)
 			continue;
 
-		    /* Yes, add the strings and clines if this is a 
+		    /* Yes, add the strings and clines if this is a
 		     * top-level call. */
 		    if (!test && (!he || (llen + alen))) {
 			char *op, *lp, *map, *wap, *wmp;
@@ -1155,7 +1155,7 @@ comp_match(char *pfx, char *sfx, char *w, Patprog cp, Cline *clp, int qu,
 	    teststr = r;
 	if (!pattry(cp, teststr))
 	    return NULL;
-    
+
 	r = (qu == 2 ? tildequote(r, 0) : multiquote(r, !qu));
 
 	/* We still break it into parts here, trying to build a sensible
@@ -1379,7 +1379,7 @@ pattern_match_equivalence(Cpattern lp, convchar_t wind, int wmtp,
 
 /**/
 static int
-pattern_match_restrict(Cpattern p, Cpattern wp, convchar_t *wsc, int wsclen,  
+pattern_match_restrict(Cpattern p, Cpattern wp, convchar_t *wsc, int wsclen,
 		       Cpattern prestrict, ZLE_STRING_T new_line)
 {
     convchar_t c;
@@ -2180,7 +2180,7 @@ check_cmdata(Cmdata md, int sfx)
     return 0;
 }
 
-/* This puts the not-yet-matched portion back into the last cline and 
+/* This puts the not-yet-matched portion back into the last cline and
  * returns that. */
 
 static Cline

--- a/Src/Zle/compresult.c
+++ b/Src/Zle/compresult.c
@@ -51,7 +51,7 @@ cut_cline(Cline l)
     /* If no match was added with matching, we don't really know
      * which parts of the unambiguous string are worth keeping,
      * so for now we keep everything (in the hope that this
-     * produces a string containing at least everything that was 
+     * produces a string containing at least everything that was
      * originally on the line). */
 
     if (!hasmatched) {
@@ -156,7 +156,7 @@ cut_cline(Cline l)
 
 /* This builds the unambiguous string. If ins is one, it is immediately
  * inserted into the line. Otherwise csp is used to return the relative
- * cursor position in the string returned and posl contains all 
+ * cursor position in the string returned and posl contains all
  * positions with missing or ambiguous characters. If ins is two, csp
  * and posl contain real command line positions (including braces). */
 
@@ -882,7 +882,7 @@ ztat(char *nam, struct stat *buf, int ls)
 	    else
 		*p++ = *q;
 	*p = '\0';
-	
+
 	ret = ls ? lstat(nam, buf) : stat(nam, buf);
     }
 

--- a/Src/Zle/computil.c
+++ b/Src/Zle/computil.c
@@ -745,12 +745,12 @@ cd_get(char **params)
 
                 memmove(opts, opts + 1,
                         (arrlen(opts + 1) + 1) * sizeof(char *));
-                
+
             } else
                 opts[0] = ztrdup("-2V-default-");
             csl = "packed";
             break;
-  
+
         case CRT_DUMMY:
             {
                 char buf[20];
@@ -2275,7 +2275,7 @@ ca_parse_line(Cadef d, Cadef all, int multi, int first)
 		    break;
 
 		state.opt = (cur == state.nargbeg + 1 &&
-			     (!multi || !*line || 
+			     (!multi || !*line ||
 			      *line == '-' || *line == '+'));
 		state.optbeg = state.nargbeg;
 		state.argbeg = cur - 1;
@@ -2351,7 +2351,7 @@ ca_parse_line(Cadef d, Cadef all, int multi, int first)
 		}
 	    } else {
 		ca_laststate.def = adef;
-		ca_laststate.opt = (!arglast || !multi || !*line || 
+		ca_laststate.opt = (!arglast || !multi || !*line ||
 				    *line == '-' || *line == '+');
 		ca_laststate.ddef = NULL;
 		ca_laststate.dopt = NULL;
@@ -2629,7 +2629,7 @@ bin_comparguments(char *nam, char **args, UNUSED(Options ops), UNUSED(int func))
         /* This returns the descriptions, actions and sub-contexts for the
          * things _arguments has to execute at this place on the line (the
          * sub-contexts are used as tags).
-         * The return value is particularly important here, it says if 
+         * The return value is particularly important here, it says if
          * there are arguments to complete at all. */
 	{
 	    LinkList descr, act, subc;
@@ -3642,7 +3642,7 @@ bin_compquote(char *nam, char **args, Options ops, UNUSED(int func))
 	if ((v = getvalue(&vbuf, &name, 0))) {
 	    switch (PM_TYPE(v->pm->node.flags)) {
 	    case PM_SCALAR:
-		setstrvalue(v, ztrdup(comp_quote(getstrvalue(v), 
+		setstrvalue(v, ztrdup(comp_quote(getstrvalue(v),
 						 OPT_ISSET(ops,'p'))));
 		break;
 	    case PM_ARRAY:
@@ -4373,13 +4373,13 @@ cfp_matcher_range(Cmatcher *ms, char *add)
 			} else
 			    len += newlen + 1;
 			break;
-			    
+
 		    case CPAT_CCLASS:
 			/*
 			 * If there is an equivalence only on one
 			 * side it's not equivalent to anything.
 			 * Treat it as an ordinary character class.
-			 */ 
+			 */
 		    case CPAT_EQUIV:
 		    case CPAT_CHAR:
 			if (ret)
@@ -4898,7 +4898,7 @@ cf_remove_other(char **names, char *pre, int *amb)
  * SYNOPSIS:
  *     1. compfiles -p  parnam1 parnam2 skipped matcher sdirs parnam3 varargs [..varargs]
  *     2. compfiles -p- parnam1 parnam2 skipped matcher sdirs parnam3 varargs [..varargs]
- *     3. compfiles -P  parnam1 parnam2 skipped matcher sdirs parnam3 
+ *     3. compfiles -P  parnam1 parnam2 skipped matcher sdirs parnam3
  *
  *     1. Set parnam1 to an array of patterns....
  *        ${(P)parnam1} is an in/out parameter.

--- a/Src/Zle/zle_hist.c
+++ b/Src/Zle/zle_hist.c
@@ -260,7 +260,7 @@ upline(char **args)
 	else
 	    CCRIGHT();
 #endif
-	    
+
     }
     return n;
 }
@@ -1671,7 +1671,7 @@ doisearch(char **args, int dir, int pattern)
 	    }
 	    set_isrch_spot(top_spot++, hl, pos, pat_hl, pat_pos, end_pos,
 			   zlemetacs, sbptr, dir, nomatch);
-	    if (sbptr >= sibuf - FIRST_SEARCH_CHAR - 2 
+	    if (sbptr >= sibuf - FIRST_SEARCH_CHAR - 2
 #ifdef MULTIBYTE_SUPPORT
 		- 2 * (int)MB_CUR_MAX
 #endif

--- a/Src/Zle/zle_keymap.c
+++ b/Src/Zle/zle_keymap.c
@@ -751,7 +751,7 @@ bin_bindkey(char *name, char **argv, Options ops, UNUSED(int func))
 		zwarnnam(name, "incompatible operation selection options");
 		return 1;
 	    }
-    n = OPT_ISSET(ops,'e') + OPT_ISSET(ops,'v') + 
+    n = OPT_ISSET(ops,'e') + OPT_ISSET(ops,'v') +
 	OPT_ISSET(ops,'a') + OPT_ISSET(ops,'M');
     if(!op->selp && n) {
 	zwarnnam(name, "keymap cannot be selected with -%c", op->o);
@@ -1224,7 +1224,7 @@ static char *cursorptr;
 
 /* utility function for termcap output routine to add to string */
 
-static int 
+static int
 add_cursor_char(int c)
 {
     *cursorptr++ = c;
@@ -1272,7 +1272,7 @@ add_cursor_key(Keymap km, int tccode, Thingy thingy, int defchar)
      * This is necessary to make cursor keys work on many xterms with
      * both normal and application modes.
      */
-    if (buf[0] == '\33' && (buf[1] == '[' || buf[1] == 'O') && 
+    if (buf[0] == '\33' && (buf[1] == '[' || buf[1] == 'O') &&
 	buf[2] && !buf[3])
     {
 	buf[1] = (buf[1] == '[') ? 'O' : '[';
@@ -1386,12 +1386,12 @@ default_bindings(void)
     bindkey(amap, "guu", NULL, "gugu");
     bindkey(amap, "gUU", NULL, "gUgU");
 
-    /* emacs mode: arrow keys */ 
+    /* emacs mode: arrow keys */
     add_cursor_key(emap, TCUPCURSOR, t_uplineorhistory, 'A');
     add_cursor_key(emap, TCDOWNCURSOR, t_downlineorhistory, 'B');
     add_cursor_key(emap, TCLEFTCURSOR, t_backwardchar, 'D');
     add_cursor_key(emap, TCRIGHTCURSOR, t_forwardchar, 'C');
-   
+
     /* emacs mode: ^X sequences */
     bindkey(emap, "\30*",   refthingy(t_expandword), NULL);
     bindkey(emap, "\30g",   refthingy(t_listexpand), NULL);

--- a/Src/Zle/zle_main.c
+++ b/Src/Zle/zle_main.c
@@ -188,7 +188,7 @@ mod_export char *zlenoargs[1] = { NULL };
 static char **raw_lp, **raw_rp;
 
 /*
- * File descriptors we are watching as well as the terminal fd. 
+ * File descriptors we are watching as well as the terminal fd.
  * These are all for reading; we don't watch for writes or exceptions.
  */
 /**/

--- a/Src/Zle/zle_refresh.c
+++ b/Src/Zle/zle_refresh.c
@@ -650,7 +650,7 @@ zwcwrite(const REFRESH_STRING s, size_t i)
    I've put my fingers into just about every routine in here -
    any queries about updates to mason@primenet.com.au */
 
-static REFRESH_STRING 
+static REFRESH_STRING
     *nbuf = NULL,		/* new video buffer line-by-line array */
     *obuf = NULL;		/* old video buffer line-by-line array */
 static int more_start,		/* more text before start of screen?	    */
@@ -709,7 +709,7 @@ void
 resetvideo(void)
 {
     int ln;
- 
+
     winw = zterm_columns;  /* terminal width */
     if (termflags & TERM_SHORT)
 	winh = 1;
@@ -1146,7 +1146,7 @@ zrefresh(void)
 	txtattrmask = 0;
 
 	if (trashedzle && !clearflag)
-	    reexpandprompt(); 
+	    reexpandprompt();
 	resetvideo();
 	resetneeded = 0;	/* unset */
 	oput_rpmpt = 0;		/* no right-prompt currently on screen */
@@ -1181,7 +1181,7 @@ zrefresh(void)
     } else if (winw != zterm_columns || rwinh != zterm_lines)
 	resetvideo();
 
-/* now winw equals columns and winh equals lines 
+/* now winw equals columns and winh equals lines
    width comparisons can be made with winw, height comparisons with winh */
 
     if (termflags & TERM_SHORT) {
@@ -1192,7 +1192,7 @@ zrefresh(void)
     if (tmpcs < 0) {
 #ifdef DEBUG
 	fprintf(stderr, "BUG: negative cursor position\n");
-	fflush(stderr); 
+	fflush(stderr);
 #endif
 	tmpcs = 0;
     }
@@ -1449,7 +1449,7 @@ zrefresh(void)
 	int outll, outsz, all_atr_on, all_atr_off;
 	char *statusdup = ztrdup(statusline);
 	ZLE_STRING_T outputline =
-	    stringaszleline(statusdup, 0, &outll, &outsz, NULL); 
+	    stringaszleline(statusdup, 0, &outll, &outsz, NULL);
 
 	all_atr_on = special_atr_on;
 	all_atr_off = TXT_ATTR_OFF_FROM_ON(all_atr_on);
@@ -1826,7 +1826,7 @@ refreshline(int ln)
 	&& tccan(TCCLEAREOL)) {
 	moveto(ln, 0);
 	tcoutclear(TCCLEAREOL);
-	return;	
+	return;
     }
 
 /* 1: pad out the new buffer with spaces to contain _all_ of the characters
@@ -2009,11 +2009,11 @@ refreshline(int ln)
 	    }
 
 	    /* inserting & deleting chars: we can if there's no right-prompt */
-	    if ((ln || !put_rpmpt || !oput_rpmpt) 
+	    if ((ln || !put_rpmpt || !oput_rpmpt)
 #ifdef MULTIBYTE_SUPPORT
 		&& ol->chr != WEOF && nl->chr != WEOF
 #endif
-		&& nl[1].chr && ol[1].chr && !ZR_equal(ol[1], nl[1])) { 
+		&& nl[1].chr && ol[1].chr && !ZR_equal(ol[1], nl[1])) {
 
 		/* deleting characters - see if we can find a match series that
 		   makes it cheaper to delete intermediate characters
@@ -2053,7 +2053,7 @@ refreshline(int ln)
 		 * should be annihilated, but we don't do this if we're on the
 		 * last line lest undesired scrolling occurs due to `illegal'
 		 * characters on screen
-		 */ 
+		 */
 		if (tccan(TCINS) && (vln != zterm_lines - 1)) {
 		    /* not on last line */
 		    for (i = 1; nl[i].chr; i++) {
@@ -2284,7 +2284,7 @@ tc_rightcurs(int ct)
 #ifndef MULTIBYTE_SUPPORT
 	if ((int)strlen(lpromptbuf) == lpromptw)
 	    fputs(lpromptbuf + i, shout);
-	else 
+	else
 #endif
 	if (tccan(TCRIGHT) && (tclen[TCRIGHT] * ct <= ztrlen(lpromptbuf)))
 	    /* it is cheaper to send TCRIGHT than reprint the whole prompt */

--- a/Src/Zle/zle_thingy.c
+++ b/Src/Zle/zle_thingy.c
@@ -889,7 +889,7 @@ bin_zle_fd(char *name, char **args, Options ops, UNUSED(char func))
 	    /* zrealloc handles NULL pointers, so OK for first time through */
 	    int newnwatch = nwatch+1;
 	    Watch_fd new_fd;
-	    watch_fds = (Watch_fd)zrealloc(watch_fds, 
+	    watch_fds = (Watch_fd)zrealloc(watch_fds,
 					   newnwatch * sizeof(struct watch_fd));
 	    new_fd = watch_fds + nwatch;
 	    new_fd->fd = fd;

--- a/Src/Zle/zle_tricky.c
+++ b/Src/Zle/zle_tricky.c
@@ -75,7 +75,7 @@ mod_export char *origline;
 mod_export int origcs, origll;
 
 /* Words on the command line, for use in completion */
- 
+
 /**/
 mod_export int clwsize, clwnum, clwpos;
 /**/
@@ -2296,7 +2296,7 @@ doexpansion(char *s, int lst, int olst, int explincmd)
 	goto end;
     }
     if (lst == COMP_LIST_EXPAND) {
-	/* Only the list of expansions was requested. Restore the 
+	/* Only the list of expansions was requested. Restore the
          * command line. */
         zlemetacs = 0;
         foredel(zlemetall, CUT_RAW);

--- a/Src/builtin.c
+++ b/Src/builtin.c
@@ -1038,7 +1038,7 @@ cd_do_chdir(char *cnam, char *dest, int hard)
 	    if (!(*pp)[0] || ((*pp)[0] == '.' && (*pp)[1] == '\0'))
 		hasdot = 1;
     /*
-     * If 
+     * If
      * (- there is no . in cdpath
      *  - or cdpath is not being used)
      *  - and the POSIXCD option is not set

--- a/Src/glob.c
+++ b/Src/glob.c
@@ -655,7 +655,7 @@ scanner(Complist q, int shortcircuit)
 		memcpy((char *)&errsfound, fn, sizeof(int));
 		fn += sizeof(int);
 		/* scan next level */
-		scanner((q->closure) ? q : q->next, shortcircuit); 
+		scanner((q->closure) ? q : q->next, shortcircuit);
 		if (shortcircuit && shortcircuit == matchct)
 		    return;
 		pathbuf[pathpos = oppos] = '\0';
@@ -1772,7 +1772,7 @@ zglob(LinkList list, LinkNode np, int nountok)
 			    qfirst = qn;
 			    for (qlast = qfirst; qlast->next;
 				 qlast = qlast->next)
-				;			    
+				;
 			} else
 			    qfirst = dup_qual_list(qn, &qlast);
 			/* ... link into new `or' chain ... */

--- a/Src/hashtable.c
+++ b/Src/hashtable.c
@@ -580,17 +580,17 @@ bin_hashinfo(UNUSED(char *nam), UNUSED(char **args), UNUSED(Options ops), UNUSED
 /********************************/
 
 /* hash table containing external commands */
- 
+
 /**/
 mod_export HashTable cmdnamtab;
- 
+
 /* how far we've hashed the PATH so far */
- 
+
 /**/
 mod_export char **pathchecked;
 
 /* Create a new command hash table */
- 
+
 /**/
 void
 createcmdnamtable(void)
@@ -707,7 +707,7 @@ static void
 fillcmdnamtable(UNUSED(HashTable ht))
 {
     char **pq;
- 
+
     for (pq = pathchecked; *pq; pq++)
 	hashdir(pq);
 
@@ -719,16 +719,16 @@ static void
 freecmdnamnode(HashNode hn)
 {
     Cmdnam cn = (Cmdnam) hn;
- 
+
     zsfree(cn->node.nam);
     if (cn->node.flags & HASHED)
 	zsfree(cn->u.cmd);
- 
+
     zfree(cn, sizeof(struct cmdnam));
 }
 
 /* Print an element of the cmdnamtab hash table (external command) */
- 
+
 /**/
 static void
 printcmdnamnode(HashNode hn, int printflags)
@@ -736,7 +736,7 @@ printcmdnamnode(HashNode hn, int printflags)
     Cmdnam cn = (Cmdnam) hn;
 
     if (printflags & PRINT_WHENCE_WORD) {
-	printf("%s: %s\n", cn->node.nam, (cn->node.flags & HASHED) ? 
+	printf("%s: %s\n", cn->node.nam, (cn->node.flags & HASHED) ?
 	       "hashed" : "command");
 	return;
     }
@@ -903,7 +903,7 @@ freeshfuncnode(HashNode hn)
 }
 
 /* Print a shell function */
- 
+
 /**/
 static void
 printshfuncnode(HashNode hn, int printflags)
@@ -918,7 +918,7 @@ printshfuncnode(HashNode hn, int printflags)
 	putchar('\n');
 	return;
     }
- 
+
     if ((printflags & (PRINT_WHENCE_VERBOSE|PRINT_WHENCE_WORD)) &&
 	!(printflags & PRINT_WHENCE_FUNCDEF)) {
 	nicezputs(f->node.nam, stdout);
@@ -937,7 +937,7 @@ printshfuncnode(HashNode hn, int printflags)
 	putchar('\n');
 	return;
     }
- 
+
     quotedzputs(f->node.nam, stdout);
     if (f->funcdef || f->node.flags & PM_UNDEFINED) {
 	printf(" () {\n");
@@ -1167,15 +1167,15 @@ printreswdnode(HashNode hn, int printflags)
 /********************************/
 
 /* hash table containing the aliases */
- 
+
 /**/
 mod_export HashTable aliastab;
- 
+
 /* has table containing suffix aliases */
 
 /**/
 mod_export HashTable sufaliastab;
- 
+
 /* Create new hash tables for aliases */
 
 /**/
@@ -1238,7 +1238,7 @@ static void
 freealiasnode(HashNode hn)
 {
     Alias al = (Alias) hn;
- 
+
     zsfree(al->node.nam);
     zsfree(al->text);
     zfree(al, sizeof(struct alias));
@@ -1305,7 +1305,7 @@ printaliasnode(HashNode hn, int printflags)
     if (printflags & PRINT_LIST) {
 	/* Fast fail on unrepresentable values. */
 	if (strchr(a->node.nam, '=')) {
-	    zwarn("invalid alias '%s' encountered while printing aliases", 
+	    zwarn("invalid alias '%s' encountered while printing aliases",
 		  a->node.nam);
 	    /* ### TODO: Return an error status to the C caller */
 	    return;

--- a/Src/hist.c
+++ b/Src/hist.c
@@ -55,7 +55,7 @@ void (*hwend) _((void));
 void (*addtoline) _((int));
 
 /* != 0 means history substitution is turned off */
- 
+
 /**/
 mod_export int stophist;
 
@@ -83,7 +83,7 @@ mod_export int excs, exlast;
  * Note curhist is passed to zle on variable length argument list:
  * type must match that retrieved in zle_main_entry.
  */
- 
+
 /**/
 mod_export zlong curhist;
 
@@ -101,25 +101,25 @@ zlong histlinect;
 HashTable histtab;
 /**/
 mod_export Histent hist_ring;
- 
+
 /* capacity of history lists */
- 
+
 /**/
 zlong histsiz;
- 
+
 /* desired history-file size (in lines) */
- 
+
 /**/
 zlong savehistsiz;
- 
+
 /* if = 1, we have performed history substitution on the current line *
  * if = 2, we have used the 'p' modifier                              */
- 
+
 /**/
 int histdone;
- 
+
 /* state of the history mechanism */
- 
+
 /**/
 int histactive;
 
@@ -154,22 +154,22 @@ short *chwords;
 int chwordlen, chwordpos;
 
 /* the last l for s/l/r/ history substitution */
- 
+
 /**/
 char *hsubl;
 
 /* the last r for s/l/r/ history substitution */
- 
+
 /**/
 char *hsubr;
- 
+
 /* pointer into the history line */
- 
+
 /**/
 mod_export char *hptr;
- 
+
 /* the current history line */
- 
+
 /**/
 mod_export char *chline;
 
@@ -194,14 +194,14 @@ mod_export char *zle_chline;
 
 /**/
 int qbang;
- 
+
 /* max size of histline */
- 
+
 /**/
 int hlinesz;
- 
+
 /* default event (usually curhist-1, that is, "!!") */
- 
+
 static zlong defev;
 
 /*
@@ -578,7 +578,7 @@ histsubchar(int c)
      *
      * Include the character we are attempting to substitute.
      */
-    lexraw_mark = zshlex_raw_mark(-1); 
+    lexraw_mark = zshlex_raw_mark(-1);
 
     /* look, no goto's */
     if (isfirstch && c == hatchar) {
@@ -1220,7 +1220,7 @@ addhistnum(zlong hl, int n, int xflags)
 {
     int dir = n < 0? -1 : n > 0? 1 : 0;
     Histent he = gethistent(hl, dir);
-			     
+
     if (!he)
 	return 0;
     if (he->histnum != hl)
@@ -1334,7 +1334,7 @@ putoldhistentryontop(short keep_going)
 Histent
 prepnexthistent(void)
 {
-    Histent he; 
+    Histent he;
     int curline_in_ring = hist_ring == &curline;
 
     if (curline_in_ring)
@@ -1637,7 +1637,7 @@ ihwend(void)
 	    chwords[chwordpos++] = hptr - chline;
 	    if (chwordpos >= chwordlen) {
 		chwords = (short *) realloc(chwords,
-					    (chwordlen += 32) * 
+					    (chwordlen += 32) *
 					    sizeof(short));
 	    }
 	} else {
@@ -3201,7 +3201,7 @@ histfileIsLocked(void)
 }
 
 /*
- * Get the words in the current buffer. Using the lexer. 
+ * Get the words in the current buffer. Using the lexer.
  *
  * As far as I can make out, this is a gross hack based on a gross hack.
  * When analysing lines from within zle, we tweak the metafied line

--- a/Src/init.c
+++ b/Src/init.c
@@ -48,7 +48,7 @@ char *zunderscore;
 int underscorelen, underscoreused;
 
 /* what level of sourcing we are at */
- 
+
 /**/
 int sourcelevel;
 
@@ -63,12 +63,12 @@ mod_export int SHTTY;
 mod_export FILE *shout;
 
 /* termcap strings */
- 
+
 /**/
 mod_export char *tcstr[TC_COUNT];
 
 /* lengths of each termcap string */
- 
+
 /**/
 mod_export int tclen[TC_COUNT];
 
@@ -722,7 +722,7 @@ init_shout(void)
     if (shout)
 	setvbuf(shout, shoutbuf, _IOFBF, BUFSIZ);
 #endif
-  
+
     gettyinfo(&shttyinfo);	/* get tty state */
 #if defined(__sgi)
     if (shttyinfo.tio.c_cc[VSWTCH] <= 0)	/* hack for irises */
@@ -1386,7 +1386,7 @@ source(char *s)
     struct funcstack fstack;
     enum source_return ret = SOURCE_OK;
 
-    if (!s || 
+    if (!s ||
 	(!(prog = try_source_file((us = unmeta(s)))) &&
 	 (tempfd = movefd(open(us, O_RDONLY | O_NOCTTY))) == -1)) {
 	return SOURCE_NOT_FOUND;
@@ -1727,7 +1727,7 @@ zsh_main(UNUSED(int argc), char **argv)
 
     createoptiontable();
     /* sets emulation, LOGINSHELL, PRIVILEGED, ZLE, INTERACTIVE,
-     * SHINSTDIN and SINGLECOMMAND */ 
+     * SHINSTDIN and SINGLECOMMAND */
     parseargs(zsh_name, argv, &runscript, &cmd);
 
     SHTTY = -1;

--- a/Src/input.c
+++ b/Src/input.c
@@ -35,7 +35,7 @@
  * flags marking the end of alias expansion, with minimal copying of
  * strings.  The same stack is used to record the fact that the input
  * is a history or alias expansion and to store the alias while it is in use.
- * 
+ *
  * Input is taken either from zle, if appropriate, or read directly from
  * the input file, or may be supplied by some other part of the shell (such
  * as `eval' or $(...) substitution).  In the last case, it should be
@@ -47,7 +47,7 @@
  * (push supplied alias onto stack) or INP_HIST (ditto, but used to
  * mark history expansion).  `alias' is ignored unless INP_ALIAS or
  * INP_HIST is supplied.  INP_ALIAS is always set if INP_HIST is.
- * 
+ *
  * Note that the input string is itself used as the input buffer: it is not
  * copied, nor is it every written back to, so using a constant string
  * should work.  Consequently, when passing areas of memory from the heap
@@ -86,10 +86,10 @@ int SHIN;
 FILE *bshin;
 
 /* != 0 means we are reading input from a string */
- 
+
 /**/
 int strin;
- 
+
 /* total # of characters waiting to be read. */
 
 /**/
@@ -412,7 +412,7 @@ inputsetline(char *str, int flags)
  * expand an alias or a history reference.
  * In fact, the character is ignored and the previous character is used.
  * (If that's wrong, the bug is in the calling code.  Use the #ifdef DEBUG
- * code to check.) 
+ * code to check.)
  */
 
 /**/

--- a/Src/jobs.c
+++ b/Src/jobs.c
@@ -40,24 +40,24 @@ mod_export pid_t origpgrp;
 
 /**/
 mod_export pid_t mypgrp;
- 
+
 /* the job we are working on */
- 
+
 /**/
 mod_export int thisjob;
 
 /* the current job (+) */
- 
+
 /**/
 mod_export int curjob;
- 
+
 /* the previous job (-) */
- 
+
 /**/
 mod_export int prevjob;
- 
+
 /* the job table */
- 
+
 /**/
 mod_export struct job *jobtab;
 
@@ -78,7 +78,7 @@ static struct job *oldjobtab;
 static int oldmaxjob;
 
 /* shell timings */
- 
+
 /**/
 #ifdef HAVE_GETRUSAGE
 /**/
@@ -89,9 +89,9 @@ static struct rusage child_usage;
 static struct tms shtms;
 /**/
 #endif
- 
+
 /* 1 if ttyctl -f has been executed */
- 
+
 /**/
 mod_export int ttyfrozen;
 
@@ -130,7 +130,7 @@ makerunning(Job jn)
     jn->stat &= ~STAT_STOPPED;
     for (pn = jn->procs; pn; pn = pn->next) {
 #if 0
-	if (WIFSTOPPED(pn->status) && 
+	if (WIFSTOPPED(pn->status) &&
 	    (!(jn->stat & STAT_SUPERJOB) || pn->next))
 	    pn->status = SP_RUNNING;
 #endif
@@ -186,7 +186,7 @@ findproc(pid_t pid, Job *jptr, Process *pptr, int aux)
 	    if (pn->pid == pid) {
 		*pptr = pn;
 		*jptr = jobtab + i;
-		if (pn->status == SP_RUNNING) 
+		if (pn->status == SP_RUNNING)
 		    return 1;
 	    }
 	}
@@ -302,7 +302,7 @@ handle_sub(int job, int fg)
 /* Get the latest usage information */
 
 /**/
-void 
+void
 get_usage(void)
 {
 #ifdef HAVE_GETRUSAGE
@@ -347,7 +347,7 @@ update_process(Process pn, int status)
 /*
  * Called when the current shell is behaving as if it received
  * a interactively generated signal (sig).
- * 
+ *
  * As we got the signal or are pretending we did, we need to pretend
  * anything attached to a CURSH process got it, too.
  */
@@ -484,7 +484,7 @@ update_job(Job jn)
 
     if (shout && shout != stderr && !ttyfrozen && !jn->stty_in_env &&
 	!zleactive && job == thisjob && !somestopped &&
-	!(jn->stat & STAT_NOSTTY)) 
+	!(jn->stat & STAT_NOSTTY))
 	gettyinfo(&shttyinfo);
 
     if (isset(MONITOR)) {
@@ -789,7 +789,7 @@ printtime(struct timeval *real, child_times_t *ti, char *desc)
 #endif
 #ifdef HAVE_STRUCT_RUSAGE_RU_IXRSS
 	    case 'X':
-		fprintf(stderr, "%ld", 
+		fprintf(stderr, "%ld",
 			total_time ?
 			(long)(ti->ru_ixrss / total_time) :
 			(long)0);
@@ -798,7 +798,7 @@ printtime(struct timeval *real, child_times_t *ti, char *desc)
 #ifdef HAVE_STRUCT_RUSAGE_RU_IDRSS
 	    case 'D':
 		fprintf(stderr, "%ld",
-			total_time ? 
+			total_time ?
 			(long) ((ti->ru_idrss
 #ifdef HAVE_STRUCT_RUSAGE_RU_ISRSS
 				 + ti->ru_isrss
@@ -1755,13 +1755,13 @@ shelltime(void)
 }
 
 /* see if jobs need printing */
- 
+
 /**/
 void
 scanjobs(void)
 {
     int i;
- 
+
     for (i = 1; i <= maxjob; i++)
         if (jobtab[i].stat & STAT_CHANGED)
             printjob(jobtab + i, !!isset(LONGLISTJOBS), 1);
@@ -2245,7 +2245,7 @@ bin_fg(char *name, char **argv, Options ops, int func)
 		if (job != ignorejob && jobptr->stat) {
 		    if ((!OPT_ISSET(ops,'r') && !OPT_ISSET(ops,'s')) ||
 			(OPT_ISSET(ops,'r') && OPT_ISSET(ops,'s')) ||
-			(OPT_ISSET(ops,'r') && 
+			(OPT_ISSET(ops,'r') &&
 			 !(jobptr->stat & STAT_STOPPED)) ||
 			(OPT_ISSET(ops,'s') && jobptr->stat & STAT_STOPPED))
 			printjob(jobptr, lng, 2);
@@ -2667,7 +2667,7 @@ bin_kill(char *nam, char **argv, UNUSED(Options ops), UNUSED(int func))
 	    if (kill(pid, sig) == -1) {
 		zwarnnam("kill", "kill %s failed: %e", *argv, errno);
 		returnval++;
-	    } 
+	    }
 #ifndef WIFCONTINUED
 	    else if (sig == SIGCONT) {
 		Job jn;

--- a/Src/lex.c
+++ b/Src/lex.c
@@ -60,17 +60,17 @@ mod_export int tokfd;
 zlong toklineno;
 
 /* lexical analyzer error flag */
- 
+
 /**/
 mod_export int lexstop;
 
 /* if != 0, this is the first line of the command */
- 
+
 /**/
 mod_export int isfirstln;
- 
+
 /* if != 0, this is the first char of the command (not including white space) */
- 
+
 /**/
 int isfirstch;
 
@@ -85,7 +85,7 @@ int inalmore;
  * set when we detect a lookahead that stops the word from
  * needing correction.
  */
- 
+
 /**/
 int nocorrect;
 
@@ -789,7 +789,7 @@ gettok(void)
 		     */
 		    tokstr = NULL;
 		    return INPAR;
-		    
+
 		case CMD_OR_MATH_ERR:
 		    /*
 		     * LEXFLAGS_ACTIVE means we came from bufferwords(),
@@ -942,7 +942,7 @@ gettokstr(int c, int sub)
 	int act;
 	int e;
 	int inbl = inblank(c);
-	
+
 	if (fdpar && !inbl && c != ')')
 	    fdpar = 0;
 

--- a/Src/loop.c
+++ b/Src/loop.c
@@ -31,17 +31,17 @@
 #include "loop.pro"
 
 /* # of nested loops we are in */
- 
+
 /**/
 int loops;
- 
+
 /* # of continue levels */
- 
+
 /**/
 mod_export int contflag;
- 
+
 /* # of break levels */
- 
+
 /**/
 mod_export int breaks;
 
@@ -154,7 +154,7 @@ execfor(Estate state, int do_exec)
 		name = (char *)getdata(node);
 		if (!args || !(str = (char *) ugetnode(args)))
 		{
-		    if (count) { 
+		    if (count) {
 			str = "";
 			last = 1;
 		    } else

--- a/Src/math.c
+++ b/Src/math.c
@@ -35,10 +35,10 @@ struct mathvalue;
 #include <math.h>
 
 /* nonzero means we are not evaluating, just parsing */
- 
+
 /**/
 int noeval;
- 
+
 /* integer zero */
 
 /**/
@@ -56,7 +56,7 @@ mnumber lastmathval;
 
 /**/
 int lastbase;
- 
+
 static char *ptr;
 
 static mnumber yyval;
@@ -226,7 +226,7 @@ static int c_prec[TOKCOUNT] =
  *                    CID (identifier with '#'), FUNC (math function)
  * 1   Opening parenthesis: M_INPAR '('  (for convenience, not an operator)
  * 2   Unary operators: PREPLUS/POSTPLUS '++', PREMINUS/POSTMINUS '--',
- *                      NOT '!', COMP '~', UPLUS '+', UMINUS '-' 
+ *                      NOT '!', COMP '~', UPLUS '+', UMINUS '-'
  * 3   SHLEFT '<<', SHRIGHT '>>'
  * 4   AND '&'
  * 5   XOR '^'
@@ -1383,7 +1383,7 @@ bop(int tk)
 
     if (stack[sp].val.type == MN_UNSET)
 	*spval = getmathparam(stack + sp);
-    tst = (spval->type & MN_FLOAT) ? (zlong)spval->u.d : spval->u.l; 
+    tst = (spval->type & MN_FLOAT) ? (zlong)spval->u.d : spval->u.l;
 
     switch (tk) {
     case DAND:

--- a/Src/mem.c
+++ b/Src/mem.c
@@ -35,7 +35,7 @@
 	to call zalloc/zshcalloc, which call malloc/calloc directly.  It
 	is legal to call realloc() or free() on memory allocated this way.
 	The second way is to call zhalloc/hcalloc, which allocates memory
-	from one of the memory pools on the heap stack.  Such memory pools 
+	from one of the memory pools on the heap stack.  Such memory pools
 	will automatically created when the heap allocation routines are
 	called.  To be sure that they are freed at appropriate times
 	one should call pushheap() before one starts using heaps and
@@ -1209,7 +1209,7 @@ malloc(MALLOC_ARG_T size)
 
     /* some systems want malloc to return the highest valid address plus one
        if it is called with an argument of zero.
-    
+
        TODO: really?  Suppose we allocate more memory, so
        that this is now in bounds, then a more rational application
        that thinks it can free() anything it malloc'ed, even
@@ -1264,7 +1264,7 @@ malloc(MALLOC_ARG_T size)
 	    m->free = sh->next;
 	    m->used++;
 
-	    /* if all small blocks in this block are allocated, the block is 
+	    /* if all small blocks in this block are allocated, the block is
 	       put at the end of the list blocks with small blocks of this
 	       size (i.e., we try to keep blocks with free blocks at the
 	       beginning of the list, to make the search faster) */

--- a/Src/module.c
+++ b/Src/module.c
@@ -1432,7 +1432,7 @@ static int
 del_automathfunc(UNUSED(const char *modnam), const char *fnam, int flags)
 {
     MathFunc f = getmathfunc(fnam, 0);
-    
+
     if (!f) {
 	if (!(flags & FEAT_IGNORE))
 	    return 2;
@@ -2435,7 +2435,7 @@ autoloadscan(HashNode hn, int printflags)
 int
 bin_zmodload(char *nam, char **args, Options ops, UNUSED(int func))
 {
-    int ops_bcpf = OPT_ISSET(ops,'b') || OPT_ISSET(ops,'c') || 
+    int ops_bcpf = OPT_ISSET(ops,'b') || OPT_ISSET(ops,'c') ||
 	OPT_ISSET(ops,'p') || OPT_ISSET(ops,'f');
     int ops_au = OPT_ISSET(ops,'a') || OPT_ISSET(ops,'u');
     int ret = 1, autoopts;
@@ -2451,7 +2451,7 @@ bin_zmodload(char *nam, char **args, Options ops, UNUSED(int func))
 	return 1;
     }
     if (OPT_ISSET(ops,'A') || OPT_ISSET(ops,'R')) {
-	if (ops_bcpf || ops_au || OPT_ISSET(ops,'d') || 
+	if (ops_bcpf || ops_au || OPT_ISSET(ops,'d') ||
 	    (OPT_ISSET(ops,'R') && OPT_ISSET(ops,'e'))) {
 	    zwarnnam(nam, "illegal flags combined with -A or -R");
 	    return 1;
@@ -2467,7 +2467,7 @@ bin_zmodload(char *nam, char **args, Options ops, UNUSED(int func))
 	zwarnnam(nam, "what do you want to unload?");
 	return 1;
     }
-    if (OPT_ISSET(ops,'e') && (OPT_ISSET(ops,'I') || OPT_ISSET(ops,'L') || 
+    if (OPT_ISSET(ops,'e') && (OPT_ISSET(ops,'I') || OPT_ISSET(ops,'L') ||
 			       (OPT_ISSET(ops,'a') && !OPT_ISSET(ops,'F'))
 			       || OPT_ISSET(ops,'d') ||
 			       OPT_ISSET(ops,'i') || OPT_ISSET(ops,'u'))) {

--- a/Src/options.c
+++ b/Src/options.c
@@ -34,7 +34,7 @@
 
 /**/
 mod_export int emulation;
- 
+
 /* current sticky emulation:  sticky = NULL means none */
 
 /**/

--- a/Src/params.c
+++ b/Src/params.c
@@ -43,12 +43,12 @@
 #endif
 
 /* what level of localness we are at */
- 
+
 /**/
 mod_export int locallevel;
 
 /* Variables holding values of special parameters */
- 
+
 /**/
 mod_export
 char **pparams,		/* $argv        */
@@ -63,7 +63,7 @@ char **pparams,		/* $argv        */
 mod_export
 char **path,		/* $path        */
      **fignore;		/* $fignore     */
- 
+
 /**/
 mod_export
 char *argzero,		/* $0           */
@@ -120,7 +120,7 @@ zlong lineno,		/* $LINENO      */
      shlvl;		/* $SHLVL       */
 
 /* $histchars */
- 
+
 /**/
 mod_export unsigned char bangchar;
 /**/
@@ -128,14 +128,14 @@ unsigned char hatchar, hashchar;
 
 /**/
 unsigned char keyboardhackchar = '\0';
- 
+
 /* $SECONDS = now.tv_sec - shtimer.tv_sec
  *          + (now.tv_usec - shtimer.tv_usec) / 1000000.0
  * (rounded to an integer if the parameter is not set to float) */
- 
+
 /**/
 struct timeval shtimer;
- 
+
 /* 0 if this $TERM setup is usable, otherwise it contains TERM_* flags */
 
 /**/
@@ -474,7 +474,7 @@ static initparam argvparam_pm = IPDEF9F("", &pparams, NULL, \
 static Param argvparam;
 
 /* hash table containing the parameters */
- 
+
 /**/
 mod_export HashTable paramtab, realparamtab;
 
@@ -851,7 +851,7 @@ createparamtable(void)
      * memory so that we can free them if needed               */
     for (
 #ifndef USE_SET_UNSET_ENV
-	envp = 
+	envp =
 #endif
 	    envp2 = environ; *envp2; envp2++) {
 	if (split_env_string(*envp2, &iname, &ivalue)) {
@@ -2278,7 +2278,7 @@ getstrvalue(Value v)
 			t = (char *) hcalloc(fwidth + t0 + 1);
 			/* prefix guaranteed to be single byte chars */
 			preflen = valprefend - s;
-			memset(t + preflen, 
+			memset(t + preflen,
 			       (((v->pm->node.flags & PM_RIGHT_B)
 				 || !zero) ?       ' ' : '0'), fwidth);
 			/*
@@ -2760,7 +2760,7 @@ setarrvalue(Value v, char **val)
 
 	post_assignment_length = v->start + arrlen(val);
 	if (v->end < pre_assignment_length) {
-	    /* 
+	    /*
 	     * Allocate room for array elements between the end of the slice `v'
 	     * and the original array's end.
 	     */
@@ -3037,7 +3037,7 @@ assignsparam(char *s, char *val, int flags)
 	    created = 1;
 	} else if ((((v->pm->node.flags & PM_ARRAY) && !(flags & ASSPM_AUGMENT)) ||
 	    	 (v->pm->node.flags & PM_HASHED)) &&
-		 !(v->pm->node.flags & (PM_SPECIAL|PM_TIED)) && 
+		 !(v->pm->node.flags & (PM_SPECIAL|PM_TIED)) &&
 		 unset(KSHARRAYS)) {
 	    unsetparam(t);
 	    createparam(t, PM_SCALAR);
@@ -4221,7 +4221,7 @@ arrayuniq(char **x, int freeok)
 	}
 	++it;
     }
-    
+
     deletehashtable(ht);
 }
 
@@ -4989,7 +4989,7 @@ arrfixenv(char *s, char **t)
 	cmdnamtab->emptytable(cmdnamtab);
 
     pm = (Param) paramtab->getnode(paramtab, s);
-    
+
     /*
      * Only one level of a parameter can be exported.  Unless
      * ALLEXPORT is set, this must be global.
@@ -5093,13 +5093,13 @@ findenv(char *name, int *pos)
 
     eq = strchr(name, '=');
     nlen = eq ? eq - name : (int)strlen(name);
-    for (ep = environ; *ep; ep++) 
+    for (ep = environ; *ep; ep++)
 	if (!strncmp (*ep, name, nlen) && *((*ep)+nlen) == '=') {
 	    if (pos)
 		*pos = ep - environ;
 	    return 1;
 	}
-    
+
     return 0;
 }
 /**/
@@ -5116,7 +5116,7 @@ zgetenv(char *name)
     return getenv(name);
 #else
     char **ep, *s, *t;
- 
+
     for (ep = environ; *ep; ep++) {
        for (s = *ep, t = name; *s && *s == *t; s++, t++);
        if (*s == '=' && !*t)
@@ -5618,7 +5618,7 @@ void
 freeparamnode(HashNode hn)
 {
     Param pm = (Param) hn;
- 
+
     /* The second argument of unsetfn() is used by modules to
      * differentiate "exp"licit unset from implicit unset, as when
      * a parameter is going out of scope.  It's not clear which

--- a/Src/parse.c
+++ b/Src/parse.c
@@ -39,26 +39,26 @@ mod_export int incmdpos;
 int aliasspaceflag;
 
 /* != 0 if we are in the middle of a [[ ... ]] */
- 
+
 /**/
 mod_export int incond;
- 
+
 /* != 0 if we are after a redirection (for ctxtlex only) */
- 
+
 /**/
 mod_export int inredir;
- 
+
 /*
  * 1 if we are about to read a case pattern
  * -1 if we are not quite sure
  * 0 otherwise
  */
- 
+
 /**/
 int incasepat;
- 
+
 /* != 0 if we just read a newline */
- 
+
 /**/
 int isnewlin;
 
@@ -82,7 +82,7 @@ mod_export int intypeset;
 
 /**/
 struct heredocs *hdocs;
- 
+
 
 #define YYERROR(O)  { tok = LEXERR; ecused = (O); return 0; }
 #define YYERRORV(O) { tok = LEXERR; ecused = (O); return; }
@@ -96,7 +96,7 @@ struct heredocs *hdocs;
 	    } while(0)
 
 
-/* 
+/*
  * Word code.
  *
  * The parser now produces word code, reducing memory consumption compared
@@ -227,7 +227,7 @@ struct heredocs *hdocs;
  * sublists is that they can be executed faster, see exec.c. In the
  * parser, the test if a list can be simplified is done quite simply
  * by passing a int* around which gets set to non-zero if the thing
- * just parsed is `cmplx', i.e. may need to be run by forking or 
+ * just parsed is `cmplx', i.e. may need to be run by forking or
  * some such.
  *
  * In each of the above, strings are encoded as one word code. For empty
@@ -246,7 +246,7 @@ struct heredocs *hdocs;
  * arrays all point to the same memory block.
  *
  *
- * To make things even faster in future versions, we could not only 
+ * To make things even faster in future versions, we could not only
  * test if the strings contain tokens, but instead what kind of
  * expansions need to be done on strings. In the execution code we
  * could then use these flags for a specialized version of prefork()
@@ -812,7 +812,7 @@ par_sublist(int *cmplx)
 	    if (tok == AMPER || tok == AMPERBANG) {
 		c = 1;
 		*cmplx |= c;
-	    }		
+	    }
 	    set_sublist_code(p, WC_SUBLIST_END, f, (e - 1 - p), c);
 	}
 	return 1;
@@ -2993,7 +2993,7 @@ init_eprog(void)
  * host the file was created on and once for the other byte-order. The
  * header describes where the beginning of the `other' version is and it
  * is up to the shell reading the file to decide which version it needs.
- * This is done by checking if the first word is FD_MAGIC (then the 
+ * This is done by checking if the first word is FD_MAGIC (then the
  * shell reading the file has the same byte order as the one that created
  * the file) or if it is FD_OMAGIC, then the `other' version has to be
  * read.
@@ -3152,7 +3152,7 @@ bin_zcompile(char *nam, char **args, Options ops, UNUSED(int func))
     queue_signals();
     ret = ((OPT_ISSET(ops,'c') || OPT_ISSET(ops,'a')) ?
 	   build_cur_dump(nam, dump, args + 1, OPT_ISSET(ops,'m'), map,
-			  (OPT_ISSET(ops,'c') ? 1 : 0) | 
+			  (OPT_ISSET(ops,'c') ? 1 : 0) |
 			  (OPT_ISSET(ops,'a') ? 2 : 0)) :
 	   build_dump(nam, dump, args + 1, OPT_ISSET(ops,'U'), map, flags));
     unqueue_signals();
@@ -3566,7 +3566,7 @@ zwcstat(char *filename, struct stat *buf)
     if (stat(filename, buf)) {
 #ifdef HAVE_FSTAT
         FuncDump f;
-    
+
 	for (f = dumps; f; f = f->next) {
 	    if (!strncmp(filename, f->filename, strlen(f->filename)) &&
 		!fstat(f->fd, buf))

--- a/Src/pattern.c
+++ b/Src/pattern.c
@@ -1117,7 +1117,7 @@ patgetglobflags(char **strp, long *assertp, int *ignore)
 
 
 static const char *colon_stuffs[]  = {
-    "alpha", "alnum", "ascii", "blank", "cntrl", "digit", "graph", 
+    "alpha", "alnum", "ascii", "blank", "cntrl", "digit", "graph",
     "lower", "print", "punct", "space", "upper", "xdigit", "IDENT",
     "IFS", "IFSSPACE", "WORD", "INCOMPLETE", "INVALID", NULL
 };
@@ -3766,7 +3766,7 @@ mb_patmatchindex(char *range, wint_t ind, wint_t *chr, int *mtp)
 	    case PP_RANGE:
 		r1 = metacharinc(&range);
 		r2 = metacharinc(&range);
-		rdiff = (wint_t)r2 - (wint_t)r1; 
+		rdiff = (wint_t)r2 - (wint_t)r1;
 		if (rdiff >= ind) {
 		    *chr = (wint_t)r1 + ind;
 		    return 1;
@@ -3999,7 +3999,7 @@ patmatchindex(char *range, int ind, int *chr, int *mtp)
 		r2 = STOUC(UNMETA(range));
 		if (*range == Meta)
 		    range++;
-		rdiff = r2 - r1; 
+		rdiff = r2 - r1;
 		if (rdiff >= ind) {
 		    *chr = r1 + ind;
 		    return 1;

--- a/Src/signals.c
+++ b/Src/signals.c
@@ -29,7 +29,7 @@
 
 #include "zsh.mdh"
 #include "signals.pro"
- 
+
 /* Array describing the state of each signal: an element contains *
  * 0 for the default action or some ZSIG_* flags ored together.   */
 
@@ -107,7 +107,7 @@ static sigset_t blocked_set;
 # define signal_setjmp(b)     setjmp(b)
 # define signal_longjmp(b,n)  longjmp((b),(n))
 #endif
- 
+
 #ifdef NO_SIGNAL_BLOCKING
 # define signal_process(sig)  signal_ignore(sig)
 # define signal_reset(sig)    install_handler(sig)
@@ -126,7 +126,7 @@ install_handler(int sig)
 {
 #ifdef POSIX_SIGNALS
     struct sigaction act;
- 
+
     act.sa_handler = (SIGNAL_HANDTYPE) zhandler;
     sigemptyset(&act.sa_mask);        /* only block sig while in handler */
     act.sa_flags = 0;
@@ -138,7 +138,7 @@ install_handler(int sig)
 #else
 # ifdef BSD_SIGNALS
     struct sigvec vec;
- 
+
     vec.sv_handler = (SIGNAL_HANDTYPE) zhandler;
     vec.sv_mask = sigmask(sig);    /* mask out this signal while in handler    */
 #  ifdef SV_INTERRUPT
@@ -159,7 +159,7 @@ install_handler(int sig)
 }
 
 /* enable ^C interrupts */
- 
+
 /**/
 mod_export void
 intr(void)
@@ -169,7 +169,7 @@ intr(void)
 }
 
 /* disable ^C interrupts */
- 
+
 #if 0 /**/
 void
 nointr(void)
@@ -178,9 +178,9 @@ nointr(void)
         signal_ignore(SIGINT);
 }
 #endif
- 
+
 /* temporarily block ^C interrupts */
- 
+
 /**/
 mod_export void
 holdintr(void)
@@ -190,7 +190,7 @@ holdintr(void)
 }
 
 /* release ^C interrupts */
- 
+
 /**/
 mod_export void
 noholdintr(void)
@@ -198,16 +198,16 @@ noholdintr(void)
     if (interact)
         signal_unblock(signal_mask(SIGINT));
 }
- 
+
 /* create a signal mask containing *
  * only the given signal           */
- 
+
 /**/
 mod_export sigset_t
 signal_mask(int sig)
 {
     sigset_t set;
- 
+
     sigemptyset(&set);
     if (sig)
         sigaddset(&set, sig);
@@ -225,14 +225,14 @@ mod_export sigset_t
 signal_block(sigset_t set)
 {
     sigset_t oset;
- 
+
 #ifdef POSIX_SIGNALS
     sigprocmask(SIG_BLOCK, &set, &oset);
 
 #else
 # ifdef SYSV_SIGNALS
     int i;
- 
+
     oset = blocked_set;
     for (i = 1; i <= NSIG; ++i) {
         if (sigismember(&set, i) && !sigismember(&blocked_set, i)) {
@@ -254,7 +254,7 @@ signal_block(sigset_t set)
    }
 # endif /* SYSV_SIGNALS */
 #endif /* POSIX_SIGNALS */
- 
+
     return oset;
 }
 
@@ -280,7 +280,7 @@ signal_unblock(sigset_t set)
 # else
 #  ifdef SYSV_SIGNALS
     int i;
- 
+
     oset = blocked_set;
     for (i = 1; i <= NSIG; ++i) {
         if (sigismember(&set, i) && sigismember(&blocked_set, i)) {
@@ -303,7 +303,7 @@ signal_unblock(sigset_t set)
 #  endif /* SYSV_SIGNALS  */
 # endif  /* BSD_SIGNALS   */
 #endif   /* POSIX_SIGNALS */
- 
+
     return oset;
 }
 
@@ -315,7 +315,7 @@ mod_export sigset_t
 signal_setmask(sigset_t set)
 {
     sigset_t oset;
- 
+
 #ifdef POSIX_SIGNALS
     sigprocmask(SIG_SETMASK, &set, &oset);
 #else
@@ -324,7 +324,7 @@ signal_setmask(sigset_t set)
 # else
 #  ifdef SYSV_SIGNALS
     int i;
- 
+
     oset = blocked_set;
     for (i = 1; i <= NSIG; ++i) {
         if (sigismember(&set, i) && !sigismember(&blocked_set, i)) {
@@ -351,7 +351,7 @@ signal_setmask(sigset_t set)
 #  endif /* SYSV_SIGNALS  */
 # endif  /* BSD_SIGNALS   */
 #endif   /* POSIX_SIGNALS */
- 
+
     return oset;
 }
 
@@ -571,7 +571,7 @@ wait_for_processes(void)
 }
 
 /* the signal handler */
- 
+
 /**/
 mod_export RETSIGTYPE
 zhandler(int sig)
@@ -582,14 +582,14 @@ zhandler(int sig)
     int do_jump;
     signal_jmp_buf jump_to;
 #endif
- 
+
     last_signal = sig;
     signal_process(sig);
- 
+
     sigfillset(&newmask);
     /* Block all signals temporarily           */
     oldmask = signal_block(newmask);
- 
+
 #if defined(NO_SIGNAL_BLOCKING)
     /* do we need to longjmp to signal_suspend */
     do_jump = suspend_longjmp;
@@ -622,15 +622,15 @@ zhandler(int sig)
         signal_reset(sig);
         return;
     }
- 
+
     /* Reset signal mask, signal traps ok now */
     signal_setmask(oldmask);
- 
+
     switch (sig) {
     case SIGCHLD:
 	wait_for_processes();
         break;
- 
+
     case SIGPIPE:
 	if (!handletrap(SIGPIPE)) {
 	    if (!interact)
@@ -648,7 +648,7 @@ zhandler(int sig)
             zexit(SIGHUP, 1);
         }
         break;
- 
+
     case SIGINT:
         if (!handletrap(SIGINT)) {
 	    if ((isset(PRIVILEGED) || isset(RESTRICTED)) &&
@@ -690,12 +690,12 @@ zhandler(int sig)
 	    }
         }
         break;
- 
+
     default:
         (void) handletrap(sig);
         break;
     }   /* end of switch(sig) */
- 
+
     signal_reset(sig);
 
 /* This is used to make signal_suspend() race-free */
@@ -706,15 +706,15 @@ zhandler(int sig)
 
 } /* handler */
 
- 
+
 /* SIGHUP any jobs left running */
- 
+
 /**/
 void
 killrunjobs(int from_signal)
 {
     int i, killed = 0;
- 
+
     if (unset(HUP))
         return;
     for (i = 1; i <= maxjob; i++)
@@ -731,7 +731,7 @@ killrunjobs(int from_signal)
 
 
 /* send a signal to a job (simply involves kill if monitoring is on) */
- 
+
 /**/
 int
 killjb(Job jn, int sig)

--- a/Src/signals.h
+++ b/Src/signals.h
@@ -55,7 +55,7 @@
 # define sigdelset(s,n)    (*(s) &= ~(1 << ((n) - 1)), 0)
 # define sigismember(s,n)  ((*(s) & (1 << ((n) - 1))) != 0)
 #endif   /* ifndef POSIX_SIGNALS */
- 
+
 #define child_block()      signal_block(sigchld_mask)
 #define child_unblock()    signal_unblock(sigchld_mask)
 

--- a/Src/sort.c
+++ b/Src/sort.c
@@ -91,7 +91,7 @@ eltpcmp(const void *a, const void *b)
 		if (be->len != -1) {
 		    /*
 		     * if a is shorter it's earlier, so return -1 and
-		     * vice versa 
+		     * vice versa
 		     */
 		    return (ae->len - be->len) * sortdir;
 		} else {

--- a/Src/subst.c
+++ b/Src/subst.c
@@ -1789,7 +1789,7 @@ paramsubst(LinkList l, LinkNode n, char **str, int qt, int pf_flags,
     int aspar = 0;
     /*
      * The (%) flag, c.f. mods again.
-     */	
+     */
     int presc = 0;
     /*
      * The (g) flag.  Process escape sequences with various GETKEY_ flags.
@@ -2322,7 +2322,7 @@ paramsubst(LinkList l, LinkNode n, char **str, int qt, int pf_flags,
 		globsubst = 2;
 	} else if (c == '+') {
 	    /*
-	     * Return whether indicated parameter is set. 
+	     * Return whether indicated parameter is set.
 	     * Try to handle this when parameter is named
 	     * by (P) (second part of test).
 	     */
@@ -2340,7 +2340,7 @@ paramsubst(LinkList l, LinkNode n, char **str, int qt, int pf_flags,
 	    }
 	} else if (inbrace && inull(*s)) {
 	    /*
-	     * Handles things like ${(f)"$(<file)"} by skipping 
+	     * Handles things like ${(f)"$(<file)"} by skipping
 	     * the double quotes.  We don't need to know what was
 	     * actually there; the presence of a String or Qstring
 	     * is good enough.

--- a/Src/text.c
+++ b/Src/text.c
@@ -938,7 +938,7 @@ gettext2(Estate state)
 				ctype == COND_STRNEQ)
 				state->pc++;
 			} else {
-			    /* Unary test: `-f foo' etc. */ 
+			    /* Unary test: `-f foo' etc. */
 			    char c2[4];
 
 			    c2[0] = '-';

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -1124,7 +1124,7 @@ finddir_scan(HashNode hn, UNUSED(int flags))
 
 /*
  * See if a path has a named directory as its prefix.
- * If passed a NULL argument, it will invalidate any 
+ * If passed a NULL argument, it will invalidate any
  * cached information.
  *
  * s here is metafied.
@@ -4122,7 +4122,7 @@ makebangspecial(int yesno)
     /* Name and call signature for congruence with makecommaspecial(),
      * but in this case when yesno is nonzero we defer to the state
      * saved by inittyptab().
-     */ 
+     */
     if (yesno == 0) {
 	typtab[bangchar] &= ~ISPECIAL;
     } else if (typtab_flags & ZTF_BANGCHAR) {

--- a/Src/zsh.h
+++ b/Src/zsh.h
@@ -135,11 +135,11 @@ struct mathfunc {
 #define STRMATHFUNC(name, func, id) \
     { NULL, name, MFF_STR, NULL, func, NULL, 0, 0, id }
 
-/* Character tokens are sometimes casted to (unsigned char)'s.         * 
- * Unfortunately, some compilers don't correctly cast signed to        * 
- * unsigned promotions; i.e. (int)(unsigned char)((char) -1) evaluates * 
- * to -1, instead of 255 like it should.  We circumvent the troubles   * 
- * of such shameful delinquency by casting to a larger unsigned type   * 
+/* Character tokens are sometimes casted to (unsigned char)'s.         *
+ * Unfortunately, some compilers don't correctly cast signed to        *
+ * unsigned promotions; i.e. (int)(unsigned char)((char) -1) evaluates *
+ * to -1, instead of 255 like it should.  We circumvent the troubles   *
+ * of such shameful delinquency by casting to a larger unsigned type   *
  * then back down to unsigned char.                                    */
 
 #ifdef BROKEN_SIGNED_TO_UNSIGNED_CASTING
@@ -875,7 +875,7 @@ struct eccstr {
 #define WCB_END()           wc_bld(WC_END, 0)
 
 #define WC_LIST_TYPE(C)     wc_data(C)
-#define Z_END               (1<<4) 
+#define Z_END               (1<<4)
 #define Z_SIMPLE            (1<<5)
 #define WC_LIST_FREE        (6)	/* Next bit available in integer */
 #define WC_LIST_SKIP(C)     (wc_data(C) >> WC_LIST_FREE)
@@ -2833,9 +2833,9 @@ struct heap {
 #endif
 
 /* Uncomment the following if the struct needs padding to 64-bit size. */
-/* Make sure sizeof(heap) is a multiple of 8 
+/* Make sure sizeof(heap) is a multiple of 8
 #if defined(PAD_64_BIT) && !defined(__GNUC__)
-    size_t dummy;		
+    size_t dummy;
 #endif
 */
 #define arena(X)	((char *) (X) + sizeof(struct heap))


### PR DESCRIPTION
This patch doesn't change any functionality. It just removes trailing whitespace from *.c and *.h files.