### PR TITLE
__git_files: fix double quotation of star

### DIFF
--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -6812,7 +6812,7 @@ __git_files () {
   local pref=$gitcdup$gitprefix$PREFIX
 
   # First allow ls-files to pattern-match in case of remote repository
-  files=(${(0)"$(_call_program files git ls-files -z --exclude-standard ${(q)opts} -- ${(q)${pref:+$pref\\\*}:-.} 2>/dev/null)"})
+  files=(${(0)"$(_call_program files git ls-files -z --exclude-standard ${(q)opts} -- ${(q)${pref:+$pref\*}:-.} 2>/dev/null)"})
   __git_command_successful $pipestatus || return
 
   # If ls-files succeeded but returned nothing, try again with no pattern


### PR DESCRIPTION
This fixes the double quote introduced by aa160fc8, so that the end result of the parameter expansion is `$pref` followed by `\*` (a quoted star), meaning `git ls-files` gets a literal star, not an expanded list of matching files, as was intended in commit cc7437bf.

This fixes the use case of trying to `git-add` files from the parent directory (`git add ../<TAB>`). I haven't tested other use cases.