### PR TITLE
add --folder-uri to command line completion for Visual Studio Code

### DIFF
--- a/Completion/X/Command/_code
+++ b/Completion/X/Command/_code
@@ -30,6 +30,7 @@ arguments=(
   '--disable-gpu[disable GPU hardware acceleration]'
   '--upload-logs[uploads logs from current session to a secure endpoint]:confirm:(iConfirmLogsUpload)'
   '--max-memory=[specify max memory size for a window]:size (Mbytes)'
+  '--folder-uri[open an URI as a folder, if there is an extension contributing a FileSystemProvider for that URI]'
   '*:filename:_files'
 )
 


### PR DESCRIPTION
`--folder-uri` is [a new parameter added to Code in version 1.26](https://code.visualstudio.com/updates/v1_26#_opening-folder-uris)