### PR TITLE
add missing math.h include for builtins

### DIFF
--- a/Src/builtin.c
+++ b/Src/builtin.c
@@ -33,6 +33,8 @@
 #include "zsh.mdh"
 #include "builtin.pro"
 
+#include <math.h>
+
 /* Builtins in the main executable */
 
 static struct builtin builtins[] =


### PR DESCRIPTION
math.h is required for isnan/isinf.
This was reported in https://github.com/NixOS/nixpkgs/pull/46452