### PR TITLE
Fix a typo in the git tag completion.

### DIFF
--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -2049,7 +2049,7 @@ _git-tag () {
       '(-i --ignore-case)'{-i,--ignore-case}'[sorting and filtering are case-insensitive]' \
       ':: :_guard "^-*" pattern' \
     - verification \
-      '(-v --verify)'{-v,--verify}'[verify gpg signutare of tags]' \
+      '(-v --verify)'{-v,--verify}'[verify gpg signature of tags]' \
       '*:: :__git_ignore_line_inside_arguments __git_tags'
 }
 


### PR DESCRIPTION
Noticed a small typo in the completion list for `git tag`. Looking at the contributing section on the Git page, I believe that this appropriate to submit via pull request. If it is not, let me know and I can submit it via a mailing list.