### PR TITLE
KDEConnect autocompletion update

### DIFF
--- a/Completion/X/Command/_kdeconnect
+++ b/Completion/X/Command/_kdeconnect
@@ -1,7 +1,9 @@
 #compdef kdeconnect-cli
 
 _kdeconnect_device-ids() {
-  compadd $(kdeconnect-cli --list-available --id-only)
+  #Use kdeconnect-cli's built-in autocomplete list, if available (newer versions)
+  #Otherwise, fall back to an older method (without descriptions)
+  _values "KDE Connect device id" "${(f)$(kdeconnect-cli --shell-device-autocompletion=zsh 2>/dev/null || kdeconnect-cli --list-available --id-only 2>/dev/null)}"
 }
 
 _arguments \
@@ -25,7 +27,8 @@ _arguments \
   '--list-commands[list remote commands and their ids]' \
   '--execute-command[execute a remote command]:command id' \
   '(-k --send-keys)'{-k,--send-keys}'[send keys to the specified device]' \
-  "--my-id[display this device's id and exit]" \
+  "--my-id[display this device's id]" \
+  "--photo[open the connected device's camera and transfer the photo]" \
   '(-)'{-h,--help}'[display usage information]' \
   '(-)'{-v,--version}'[display version information]' \
   '(-)--author[show author information and exit]' \


### PR DESCRIPTION
Use a device list with description (name and paired status) as autocompletion on newer KDE Connect versions. Also add the new option `--photo` and improve `--my-id`'s description.

I couldn't find zsh's policy on including unreleased options, so if I need to wait until a KDE Connect release until submitting this, please let me know.

Regarding the device autocomplete list with description, there might be some better way to do this. I developed the feature to output these autocompletions, so I can change it to something better (see https://invent.kde.org/kde/kdeconnect-kde/merge_requests/28). `kdeconnect-cli --zsh-device-autocomplete` outputs something like:
```
dd7972ee24a98fb5[G4 (paired)]
(more lines like that)
```