### PR TITLE
Fix _gem push completion

### DIFF
--- a/Completion/Unix/Command/_gem
+++ b/Completion/Unix/Command/_gem
@@ -214,7 +214,9 @@ if [[ $state = command ]]; then
       )
     ;;
     push)
-      args+=( '*:gem:_files -g "*.gem(-.)"' )
+      args+=(
+        '1:gem file:_files -g "*.gem(-.)"'
+      )
     ;;
     query)
       args+=(


### PR DESCRIPTION
Hi, I could reproduce the issue described in https://github.com/rubygems/rubygems/issues/2758 with zsh `5.7.1` and gem `2.5.2.1` using same arg as in `build` fixed the problem, Cheers