### PR TITLE
adjust zfs completions so that it uses acltype on linux instead of aclmode

### DIFF
--- a/Completion/Unix/Command/_zfs
+++ b/Completion/Unix/Command/_zfs
@@ -145,7 +145,6 @@ _zfs() {
 	# set the sorting for *size properties to false by default?
 	rw_properties=(
 		"aclinherit:value:(discard noallow restricted passthrough passthrough-x)"
-		$(if [[ "$OSTYPE" == "linux-gnu" ]]; then echo "acltype:value:(off noacl posixacl)"; else echo "aclmode:value:(discard mask passthrough)"; fi );
 		"atime:value:(on off)"
 		"canmount:value:(on off noauto)"
 		"checksum:value:(on off fletcher2 fletcher4 sha256 sha256+mac)"
@@ -184,6 +183,14 @@ _zfs() {
 		"zoned:value:(on off)"
 		$share_rw_properties
 	)
+
+		if [[ "$OSTYPE" == "linux-gnu" ]]; then
+			rw_properties+=("acltype:value:(off noacl posixacl)")
+		elif [[ "$OSTYPE" == "solaris*" ]]; then
+			rw_properties+=("aclmode:value:(discard mask passthrough)")
+		else
+			rw_properties+=("aclmode:value:(discard groupmask passthrough restricted)")
+		fi
 
 
 	create_properties=(

--- a/Completion/Unix/Command/_zfs
+++ b/Completion/Unix/Command/_zfs
@@ -145,7 +145,7 @@ _zfs() {
 	# set the sorting for *size properties to false by default?
 	rw_properties=(
 		"aclinherit:value:(discard noallow restricted passthrough passthrough-x)"
-		"aclmode:value:(discard mask passthrough)"
+		$(if [[ "$OSTYPE" == "linux-gnu" ]]; then echo "acltype:value:(off noacl posixacl)"; else echo "aclmode:value:(discard mask passthrough)"; fi );
 		"atime:value:(on off)"
 		"canmount:value:(on off noauto)"
 		"checksum:value:(on off fletcher2 fletcher4 sha256 sha256+mac)"
@@ -184,6 +184,7 @@ _zfs() {
 		"zoned:value:(on off)"
 		$share_rw_properties
 	)
+
 
 	create_properties=(
 		$rw_properties


### PR DESCRIPTION
zfs doesn't have an aclmode option on linux.  I set the zfs completions to use acltype instead on a linux system.  