### PR TITLE
Allow completion for picocom to list symlinks to character devices

### DIFF
--- a/Completion/Unix/Command/_picocom
+++ b/Completion/Unix/Command/_picocom
@@ -47,7 +47,7 @@ function _picocom () {
            '--omap[define output character map]:output character map:'
            '--emap[define local echo character map]:local echo character map:'
            '(--help -h)'{--help,-h}'[display help message]'
-           '*:device:_files -g "*(%c)"' )
+           '*:device:_files -g "*(-%c)"' )
 
     _arguments -C : "${args[@]}"
 }


### PR DESCRIPTION
The default picocom completion does not list symlinks to character devices.

Symlinks to character devices are useful to name devices, especially for usb-serial adapters where the name depends on the plug-in order.

This change allows the completion to list both the character devices and the symlinks to character devices.