### PR TITLE
Pass -dead_strip and -bind_at_load on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,7 +489,7 @@ fi
 if test -n "$auto_ldflags"; then
   case "${enable_zsh_debug}$host_os" in
     yesaix*|yeshpux*|yesnetbsd*|yesopenbsd*) ;;  # "ld -g" is not valid on these systems
-    darwin*) LDFLAGS=-Wl,-x ;;
+    darwin*) LDFLAGS=-Wl,-x,-dead_strip,-bind_at_load ;;
     yes*)    LDFLAGS=-g ;;
     *)       LDFLAGS=-s ;;
   esac


### PR DESCRIPTION
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Before:
```
% wc -c zsh   
  733104 zsh

% otool -l zsh
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 671744
    rebase_size 944
       bind_off 672688
      bind_size 176
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 672864
 lazy_bind_size 2992
     export_off 675856
    export_size 18856
```
After:
```
% wc -c zsh
  732224 zsh

% otool -l zsh
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 671744
    rebase_size 944
       bind_off 672688
      bind_size 2288
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 674976
    export_size 18856
```