### PR TITLE
vcs_info git: avoid warnings in bare repositories

### DIFF
--- a/Functions/VCS_Info/Backends/VCS_INFO_get_data_git
+++ b/Functions/VCS_Info/Backends/VCS_INFO_get_data_git
@@ -139,6 +139,9 @@ VCS_INFO_git_handle_patches () {
 gitdir=${vcs_comm[gitdir]}
 VCS_INFO_git_getbranch ${gitdir}
 gitbase=$( ${vcs_comm[cmd]} rev-parse --show-toplevel 2> /dev/null )
+if [[ -z ${gitbase} ]]; then
+    gitbase=${gitdir:P}
+fi
 rrn=${gitbase:t}
 if zstyle -t ":vcs_info:${vcs}:${usercontext}:${rrn}" get-revision ; then
     gitsha1=$(${vcs_comm[cmd]} rev-parse --quiet --verify HEAD)

--- a/Functions/VCS_Info/Backends/VCS_INFO_get_data_git
+++ b/Functions/VCS_Info/Backends/VCS_INFO_get_data_git
@@ -138,7 +138,7 @@ VCS_INFO_git_handle_patches () {
 
 gitdir=${vcs_comm[gitdir]}
 VCS_INFO_git_getbranch ${gitdir}
-gitbase=$( ${vcs_comm[cmd]} rev-parse --show-toplevel )
+gitbase=$( ${vcs_comm[cmd]} rev-parse --show-toplevel 2> /dev/null )
 rrn=${gitbase:t}
 if zstyle -t ":vcs_info:${vcs}:${usercontext}:${rrn}" get-revision ; then
     gitsha1=$(${vcs_comm[cmd]} rev-parse --quiet --verify HEAD)


### PR DESCRIPTION
Git 2.25 introduced a change to how git rev-parse --show-toplevel behaves.  Traditionally, it printed an empty line if the user was in a bare repository.  Now it dies, printing an error to standard error. Consequently, when the user is in a bare repository with a newer Git, vcs_info prints noisily to standard error.

While this is functionally harmless, it is annoying for the shell to print messages from Git every time the prompt is printed, so let's silence the error message.
