### PR TITLE
exec: run final pipeline command in a subshell in sh mode

### DIFF
--- a/Src/exec.c
+++ b/Src/exec.c
@@ -2866,11 +2866,13 @@ execcmd_exec(Estate state, Execcmd_params eparams,
 	    pushnode(args, dupstring("fg"));
     }
 
-    if ((how & Z_ASYNC) || output) {
+    if ((how & Z_ASYNC) || output ||
+	(last1 == 2 && input && EMULATION(EMULATE_SH))) {
 	/*
-	 * If running in the background, or not the last command in a
-	 * pipeline, we don't need any of the rest of this function to
-	 * affect the state in the main shell, so fork immediately.
+	 * If running in the background, not the last command in a
+	 * pipeline, or the last command in a multi-stage pipeline
+	 * in sh mode, we don't need any of the rest of this function
+	 * to affect the state in the main shell, so fork immediately.
 	 *
 	 * In other cases we may need to process the command line
 	 * a bit further before we make the decision.

--- a/Test/B07emulate.ztst
+++ b/Test/B07emulate.ztst
@@ -276,3 +276,25 @@ F:Some reserved tokens are handled in alias expansion
 0:--emulate followed by other options
 >yes
 >no
+
+  emulate sh -c '
+  foo () {
+    VAR=foo &&
+    echo $VAR | bar &&
+    echo "$VAR"
+  }
+  bar () {
+    tr f b &&
+    VAR="$(echo bar | tr r z)" &&
+    echo "$VAR"
+  }
+  foo
+  '
+  emulate sh -c 'func() { echo | local def="abc"; echo $def;}; func'
+  emulate sh -c 'abc="def"; echo | abc="ghi"; echo $abc'
+0:emulate sh uses subshell for last pipe entry
+>boo
+>baz
+>foo
+>
+>def


### PR DESCRIPTION
zsh typically runs the final command in a pipeline in the main shell instead of a subshell.  However, POSIX requires that all commands in a pipeline run in a subshell, but permits zsh's behavior as an extension.

Since zsh may be used as /bin/sh in some cases (such as macOS Catalina), it makes sense to have the POSIX behavior when emulating sh, so do that by checking for being the final item of a multi-item pipeline and creating a subshell in that case.

From the comment above `execpline()`, we know the following:

> last1 is a flag that this command is the last command in a shell that is about to exit, so we can exec instead of forking.  It gets passed all the way down to execcmd() which actually makes the decision.  A 0 is always passed if the command is not the last in the pipeline. […] If last1 is zero but the command is at the end of a pipeline, we pass 2 down to execcmd().

So there are three cases to consider in this code:

* last1 is 0, which means we are not at the end of a pipeline, in which case we should not change behavior.
* last1 is 1, which means we are effectively running in a subshell, because nothing that happens due to the exec is going to affect the actual shell, since it will have been replaced.  So there is nothing to do here.
* last1 is 2, which means our command is at the end of the pipeline, so in sh mode we should create a subshell by forking.

Note that several of the tests may appear bizarre, since most developers do not place useless variable assignments directly at the end of a pipeline.  However, as the function tests demonstrate, there are cases where assignments may occur when a shell function is used at the end of a command.  The remaining assignment tests simply test additional cases, such as the use of local, that would otherwise be untested.

This originally got sent to the list, but it got lost due to lack of review.  The commit message is now more informative about why this is the right solution, which may be helpful to the harried reviewer.

With this change, the Git testsuite passes when using zsh as sh.  Without it, several tests fail.