### PR TITLE
Fix dig completion error

### DIFF
--- a/Completion/Unix/Command/_dig
+++ b/Completion/Unix/Command/_dig
@@ -89,7 +89,7 @@ if [[ -n $state ]]; then
     _wanted hosts expl 'DNS server' _hosts && ret=0;
   else
     case $#line in
-      <3->) alts+=( 'classes:query class:compadd -M "m\:{a-z}={A-Z}" - IN CS CH HS' ) ;&
+      <3->) alts+=( 'classes:query class:compadd -M "m:{a-z}={A-Z}" - IN CS CH HS' ) ;&
       2) alts+=( 'types:query type:_dns_types' ) ;;
     esac
     _alternative 'hosts:host:_hosts' $alts && ret=0


### PR DESCRIPTION
Two `compadd` commands in `_dig` were changed in 2018, fixing one (for `-c`) but breaking the other.  They have the same arguments, but the arguments have different escape requirements.  In this case, the `:` should not be escaped.