### PR TITLE
Add instructions for the platform dependency

### DIFF
--- a/Doc/Zsh/mod_regex.yo
+++ b/Doc/Zsh/mod_regex.yo
@@ -28,13 +28,15 @@ If tt(BASH_REMATCH) is set, then the array tt(BASH_REMATCH) will be set
 instead of tt(MATCH) and tt(match).
 
 Note that the tt(zsh/regex) module logic relies on the host system. The 
-same var(expr) and var(regex) pair could result in different evaluations,
-especially if var(regex) with non-standard syntax is given, thus should
-be avoided.
+same var(expr) and var(regex) pair could produce different results on different
+platforms if a var(regex) with non-standard syntax is given.
 
-For example, the escape character tt(\b) representing a word boundary is
-undefined in the POSIX extended regular expression standard. It works as
-expected in GNU-Linux, but does not work (translated as a character tt(b))
-in BSD-based platforms.
+For example, no syntax for matching a word boundary is defined in the POSIX
+extended regular expression standard. GNU tt(libc) and BSD tt(libc) both provide 
+such syntaxes as extensions (tt(\b) and tt([[:<:]])/tt([[:>:]]) respectively), 
+but neither of these syntaxes is supported by both of these implementations.
+
+Refer to the manref(regcomp)(3) and manref(re_format)(7) manual pages on your
+system for locally-supported syntax.
 )
 enditem()

--- a/Doc/Zsh/mod_regex.yo
+++ b/Doc/Zsh/mod_regex.yo
@@ -26,5 +26,15 @@ tt(-regex-match) operator.
 
 If tt(BASH_REMATCH) is set, then the array tt(BASH_REMATCH) will be set
 instead of tt(MATCH) and tt(match).
+
+Note that the tt(zsh/regex) module logic relies on the host system. The 
+same var(expr) and var(regex) pair could result in different evaluations,
+especially if var(regex) with non-standard syntax is given, thus should
+be avoided.
+
+For example, the escape character tt(\b) representing a word boundary is
+undefined in the POSIX extended regular expression standard. It works as
+expected in GNU-Linux, but does not work (translated as a character tt(b))
+in BSD-based platforms.
 )
 enditem()


### PR DESCRIPTION
This add notes for the platform dependency of the module, related to the non-standard regular expressions.