### PR TITLE
Remove spurious open bracket in zsh man page

### DIFF
--- a/Doc/Zsh/metafaq.yo
+++ b/Doc/Zsh/metafaq.yo
@@ -25,7 +25,6 @@ cindex(acquiring zsh by FTP)
 cindex(availability of zsh)
 nofill(uref(ftp://ftp.zsh.org/pub/)
 uref(https://www.zsh.org/pub/))
-)
 
 The up-to-date source code is available via Git from Sourceforge.  See
 uref(https://sourceforge.net/projects/zsh/) for details.  A summary of


### PR DESCRIPTION
The spurious open bracket appears a few sentences into the zsh man page. Also [posted](https://www.zsh.org/mla/workers/2020/msg01013.html) to zsh-workers mailing list.