### PR TITLE
Completion: Fix completion for _zsh_dataset containing spaces

### DIFF
--- a/Completion/Unix/Type/_zfs_dataset
+++ b/Completion/Unix/Type/_zfs_dataset
@@ -58,14 +58,14 @@ if [[ ${#rdst} -gt 0 ]]; then
 fi
 
 if [[ -n $type[(r)clone] ]]; then
-	datasetlist=( ${="$(zfs list -H -o name,origin -t filesystem 2>/dev/null | awk "\$2 != \"-\" {print \$1}")":#no cloned filesystems available} )
+	datasetlist=( ${(f)"$(zfs list -H -o name,origin -t filesystem 2>/dev/null | awk -F $'\t' "\$2 != \"-\" {print \$1}")":#no cloned filesystems available} )
 else
-	datasetlist=( ${="$(zfs list -H -o name $typearg 2>/dev/null)":#no datasets available} )
+	datasetlist=( ${(f)"$(zfs list -H -o name $typearg 2>/dev/null)":#no datasets available} )
 fi
 
 expl_type=${typearg[2,-1]//,/\/}
 if [[ -n $type[(r)mtpt] ]]; then
-	mlist=( ${="$(zfs list -H -o mountpoint $typearg 2>/dev/null)":#no mountpoints available} )
+	mlist=( ${(f)"$(zfs list -H -o mountpoint $typearg 2>/dev/null)":#no mountpoints available} )
 	datasetlist=( $datasetlist $mlist )
 	expl_type="$expl_type/mountpoint"
 fi


### PR DESCRIPTION
I don't know if this is the case for all ZFS implementations, but spaces are allowed on OpenZFS / Linux in dataset names. In the current implementation, the trailing part of these datasets will appear as a new completion entry and the real path can never be completed. Since we're already passing the `-H` flag which uses tab-separation and each dataset appears on it's own line, we just need to limit word splitting to newlines.

Reproduction:

```
# zfs create rpool/storage/my\ data
# zfs list [tab]
[ filesystem/volume/snapshot/path ]
data rpool
```