### PR TITLE
_parameters: fix non-local variable

### DIFF
--- a/Completion/Zsh/Type/_parameters
+++ b/Completion/Zsh/Type/_parameters
@@ -6,7 +6,7 @@
 # If you specify a -g option with a pattern, the pattern will be used to
 # restrict the type of parameters matched.
 
-local expl pattern fakes faked tmp pfilt
+local expl pattern fakes faked tmp i pfilt
 
 if compset -P '*:'; then
   _history_modifiers p


### PR DESCRIPTION
Something to reproduce:

    % zstyle -e ':completion:*' matcher-list 'local -i i=0; reply=( "" )'
    % zstyle ':completion:*' fake-parameters 'ENVVAR:scalar'
    % ENV<Tab>
    _parameters:22: bad math expression: ':' without '?'