### PR TITLE
_date_formats: return proper exit status

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-07-15  oxiedi  <oxiedi@yandex.ru>
+
+	* github #62: Completion/Unix/Type/_date_formats: return proper
+	exit status
+
 2020-07-14  Daniel Shahaf  <d.s@daniel.shahaf.name>
 
 	* 46244 (cont.): Etc/creating-a-release.txt: Flesh out the TODO

--- a/Completion/Unix/Type/_date_formats
+++ b/Completion/Unix/Type/_date_formats
@@ -1,6 +1,6 @@
 #autoload
 
-local flag
+local flag ret=1
 local -aU specs
 local -A exclusion
 
@@ -106,5 +106,8 @@ for flag in ${(s..)PREFIX#%}; do
 done
 
 _describe -t date-format-specifier 'date format specifier' specs \
-    -p "${(Q)PREFIX:-%}" -S ''
-[[ $1 == zsh ]] && _message -e date-format-precision 'precision for %%. (1-9)'
+    -p "${(Q)PREFIX:-%}" -S '' && ret=0
+[[ $1 == zsh ]] && _message -e date-format-precision \
+    'precision for %%. (1-9)' && ret=0
+
+return ret


### PR DESCRIPTION
It fixes messed up completion for the following:

    % zstyle ':completion:*' matcher-list '' ''
    % date +<Tab>