### PR TITLE
Update _nmap

### DIFF
--- a/Completion/Unix/Command/_nmap
+++ b/Completion/Unix/Command/_nmap
@@ -17,7 +17,7 @@ _arguments -C \
   '-h[show help information]' \
   '*-o-[log results]:log format:->log-forms:log filename:_files' \
   '--resume[resume cancelled scan]:log filename:_files' \
-  '--append_output[append results to any log files]' \
+  '--append-output[append results to any log files]' \
   '-iL[read target specifications from file]:file:_files' \
   '-iR[scan random hosts]:num hosts' \
   '-p[specify ports to try]:port numbers' \
@@ -26,24 +26,24 @@ _arguments -C \
   '-S[specify source address]:address:_hosts' \
   '-e[specify interface to use]:network interface:_net_interfaces' \
   '-g[specify source port number]:port number' \
-  '--data_length[add random data to packets]:data length' \
+  '--data-length[add random data to packets]:data length' \
   '(-R)-n[skip reverse DNS to speed things up]' \
   '(-n)-R[always do reverse DNS on targets]' \
   "-r[don't randomize order in which ports are scanned]" \
   '-ttl[specify IPv4 time to live for sent packets]' \
-  '--randomize_hosts[scan hosts in random order]' \
+  '--randomize-hosts[scan hosts in random order]' \
   '-M[specify maximum number of parallel TCP connects]:maximum TCP connects' \
-  '--packet_trace[show all packets sent in tcpdump-like format]' \
-  '--version_trace[show packets related to version scanning]' \
+  '--packet-trace[show all packets sent in tcpdump-like format]' \
+  '--version-trace[show packets related to version scanning]' \
   '--datadir[specify directory containing data files]:directory:_directories' \
   '-T[specify timing policy]:timing policy:(Paranoid Sneaky Polite Normal Aggressive Insane)' \
-  '--host_timeout[specify maximum time for scanning a single host]:timeout (ms)' \
-  '--max_rtt_timeout[maximum time for a probe response]:timeout (ms)' \
-  '--min_rtt_timeout[minimum time to wait for a probe response]:time (ms)' \
-  '--initial_rtt_timeout[specify initial probe timeout]:timeout (ms)' \
-  '--max_parallelism[specify max number of scans to perform in parallel]:number' \
-  '--min_parallelism[scan at least specified number of ports in parallel]:number' \
-  '--scan_delay[specify minimum amount of time between probes]:delay (ms)' \
+  '--host-timeout[specify maximum time for scanning a single host]:timeout (ms)' \
+  '--max-rtt-timeout[maximum time for a probe response]:timeout (ms)' \
+  '--min-rtt-timeout[minimum time to wait for a probe response]:time (ms)' \
+  '--initial-rtt-timeout[specify initial probe timeout]:timeout (ms)' \
+  '--max-parallelism[specify max number of scans to perform in parallel]:number' \
+  '--min-parallelism[scan at least specified number of ports in parallel]:number' \
+  '--scan-delay[specify minimum amount of time between probes]:delay (ms)' \
   '--interactive[go into interactive mode]' \
   '*:host:_hosts' && ret=0
 


### PR DESCRIPTION
Nmap commands that previously included an underscore (--max_rtt_timeout, --send_eth, --host_timeout, etc.) have been renamed to use a hyphen in the preferred format.