### PR TITLE
_man: support the man-db syntax <name>.<section> 

### DIFF
--- a/Completion/Unix/Command/_man
+++ b/Completion/Unix/Command/_man
@@ -6,7 +6,6 @@
 # - We assume that Linux distributions are using either man-db or mandoc
 # - @todo Would be nice to support completing the initial operand as a section
 #   name (on non-Solaris systems)
-# - @todo We don't support the man-db syntax <name>.<section> (e.g., `ls.1`)
 # - @todo We don't support the man-db feature of 'sub-pages' — that is, treating
 #   pairs of operands like `git diff` as `git-diff`
 # - @todo Option exclusivity isn't super accurate
@@ -415,7 +414,7 @@ _man() {
 }
 
 _man_pages() {
-  local pages sopt
+  local pages sopt tmp
 
   # What files corresponding to manual pages can end in.
   local suf='.((?|<->*|ntcl)(|.gz|.bz2|.z|.Z|.lzma))'
@@ -444,13 +443,20 @@ _man_pages() {
   # `POSIX.1.5'.
 
   [[ $variant = solaris* ]] && sopt='-s '
-  if ((CURRENT > 1 || noinsert)) ||
-      ! zstyle -t ":completion:${curcontext}:manuals.$sect_dirname" insert-sections
-  then
-    compadd "$@" - ${pages%$~suf}
-  else
-    compadd "$@" -P "$sopt$sect_dirname " - ${pages%$~suf}
+  if ! ((CURRENT > 1 || noinsert)); then
+    zstyle -s ":completion:${curcontext}:manuals.$sect_dirname" insert-sections tmp
   fi
+  case "$tmp" in
+    prepend|true|on|yes|1)
+      compadd "$@" -P "$sopt$sect_dirname " - ${pages%$~suf}
+    ;;
+    suffix)
+      compadd "$@" -s ".$sect_dirname" - ${pages%$~suf}
+    ;;
+    *)
+      compadd "$@" - ${pages%$~suf}
+    ;;
+  esac
 }
 
 _man "$@"

--- a/Completion/Zsh/Command/_zstyle
+++ b/Completion/Zsh/Command/_zstyle
@@ -62,6 +62,7 @@ styles=(
   ignore-parents         c:ignorepar
   ignored-patterns	 c:
   insert-ids             c:insert-ids
+  insert-sections	 c:insert-sections
   insert-tab             c:bool
   insert-unambiguous	 c:insunambig
   keep-prefix		 c:keep-prefix
@@ -522,6 +523,11 @@ while (( $#state )); do
     (insert-ids)
       _wanted values expl 'when to insert process IDs' \
           compadd - menu single longer
+      ;;
+
+    (insert-sections)
+      _wanted values expl 'where to insert man page section' \
+          compadd - true false prepend suffix
       ;;
 
     (fake-files)

--- a/Doc/Zsh/compsys.yo
+++ b/Doc/Zsh/compsys.yo
@@ -1838,13 +1838,17 @@ user is longer than the common prefix to the corresponding IDs.
 kindex(insert-sections, completion style)
 item(tt(insert-sections))(
 This style is used with tags of the form `tt(manuals.)var(X)' when
-completing names of manual pages. If set to `true' and the var(X) in the
-tag name matches the section number of the page being completed, the
-section number is inserted along with the page name. For example, given
+completing names of manual pages. If set and the var(X) in the tag name matches
+the section number of the page being completed, the section number is inserted
+along with the page name. For example, given
 
 example(zstyle ':completion:*:manuals.*' insert-sections true)
 
 tt(man ssh_<TAB>) may be completed to tt(man 5 ssh_config).
+
+The value may also be set to one of `tt(prepend)', or `tt(suffix)'.
+`tt(prepend)' behaves the same as `true' as in the above example, while
+`tt(suffix)' would complete tt(man ssh_<TAB>) as tt(man ssh_config.5).
 
 This is especially useful in conjunction with tt(separate-sections), as
 it ensures that the page requested of tt(man) corresponds to the one


### PR DESCRIPTION
``@todo We don't support the man-db syntax <name>.<section> (e.g., `ls.1`)``

This adds support for the above todo.  
it is enabled using append-sections. `zstyle ':completion:*:manuals.*' append-sections true`  
insert-sections takes priority so it must be disabled/not enabled in the first place in order to use.

whoops, force pushed some fixes because i made a dumb mistake due to not testing the committed code,  
and switched to `-s` for `compadd` since that adds a space after completion unlike `-S`.