### PR TITLE
Make the zpty module usable in the cygwin and msys2

### DIFF
--- a/Src/Modules/zpty.c
+++ b/Src/Modules/zpty.c
@@ -30,6 +30,13 @@
 #include "zpty.mdh"
 #include "zpty.pro"
 
+#ifdef __CYGWIN__
+#include <cygwin/version.h>
+#if defined(CYGWIN_VERSION_DLL_MAJOR) && CYGWIN_VERSION_DLL_MAJOR<3002
+#define USE_CYGWIN_FIX 1
+#endif
+#endif
+
 /* The number of bytes we normally read when given no pattern and the
  * upper bound on the number of bytes we read (even if we are give a
  * pattern). */
@@ -428,6 +435,7 @@ newptycmd(char *nam, char *pname, char **args, int echo, int nblock)
 	mypid = 0; /* trick to ensure we _exit() */
 	zexit(lastval, ZEXIT_NORMAL);
     }
+#ifndef USE_CYGWIN_FIX
     master = movefd(master);
     if (master == -1) {
 	zerrnam(nam, "cannot duplicate fd %d: %e", master, errno);
@@ -435,6 +443,9 @@ newptycmd(char *nam, char *pname, char **args, int echo, int nblock)
 	ineval = oineval;
 	return 1;
     }
+#else
+    addmodulefd(master, FDT_INTERNAL);
+#endif
 
     p = (Ptycmd) zalloc(sizeof(*p));
 

--- a/configure.ac
+++ b/configure.ac
@@ -2460,7 +2460,7 @@ if test x$ac_cv_have_dev_ptmx = xyes -o x$ac_cv_func_posix_openpt = xyes && \
    test x$ac_cv_func_ptsname = xyes; then
    AC_CACHE_CHECK([if /dev/ptmx is usable],
    ac_cv_use_dev_ptmx,
-   [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#ifdef __linux
+   [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if defined(__linux) || defined(__CYGWIN__)
 #define _GNU_SOURCE 1
 #endif
 #include <stdlib.h>


### PR DESCRIPTION
cygwin have /dev/ptmx, need defined `_GNU_SOURCE 1` to use it, but configure check /dev/ptmx is usable only defined it for linux.
Another probleam is cygwin upstream have an issue https://cygwin.com/pipermail/cygwin-developers/2021-January/012030.html, because of that issue, movefd will broken the fd opened by posix_openpt, so mast disable movefd in zpty.