### PR TITLE
update xrandr completion

### DIFF
--- a/Completion/X/Command/_xrandr
+++ b/Completion/X/Command/_xrandr
@@ -3,10 +3,10 @@
 local curcontext="$curcontext" state line expl
 typeset -A opt_args
 
-__xrandrproviders() {
+__xrandr_providers() {
   local -a provs
-  provs=(${${(f)"$(xrandr --listproviders | tail +2)"}##*:})
-  _describe -t xrandrproviders 'providers' provs
+  provs=(${${(f)"$(xrandr --listproviders)"}[2,-1]##*:})
+  compadd "$@" $provs
 }
 
 _arguments -C \
@@ -53,8 +53,8 @@ _arguments -C \
   "*--addmode:output:->outputs:name" \
   "*--delmode:output:->outputs:name" \
   '--listproviders' \
-  '--setprovideroutputsource:*:provider: __xrandrproviders' \
-  '--setprovideroffloadsink:provider: :sink' \
+  '--setprovideroutputsource:provider:__xrandr_providers:source:__xrandr_providers' \
+  '--setprovideroffloadsink:provider:__xrandr_providers:sink:__xrandr_providers' \
   '--listmonitors' \
   '--listactivemonitors' \
   '--setmonitor:name' \

--- a/Completion/X/Command/_xrandr
+++ b/Completion/X/Command/_xrandr
@@ -1,13 +1,7 @@
 #compdef xrandr
 
-local curcontext="$curcontext" state line expl
+local curcontext="$curcontext" state line expl state_descr
 typeset -A opt_args
-
-__xrandr_providers() {
-  local -a provs
-  provs=(${${(f)"$(xrandr --listproviders)"}[2,-1]##*:})
-  compadd "$@" $provs
-}
 
 _arguments -C \
   '(-d -display)'{-d,-display}':X display:_x_display' \
@@ -53,8 +47,8 @@ _arguments -C \
   "*--addmode:output:->outputs:name" \
   "*--delmode:output:->outputs:name" \
   '--listproviders' \
-  '--setprovideroutputsource:provider:__xrandr_providers:source:__xrandr_providers' \
-  '--setprovideroffloadsink:provider:__xrandr_providers:sink:__xrandr_providers' \
+  '--setprovideroutputsource:provider:->providers:source:->providers' \
+  '--setprovideroffloadsink:provider:->providers:sink:->providers' \
   '--listmonitors' \
   '--listactivemonitors' \
   '--setmonitor:name' \
@@ -80,5 +74,10 @@ case $state in
   modes)
     _wanted modes expl mode compadd \
         ${(Mun)$(_call_program modes xrandr):#[0-9]##x[0-9]##} && return 0
+  ;;
+  providers)
+    local -a provs
+    provs=(${${(f)"$(xrandr --listproviders)"}[2,-1]##*:})
+    _wanted xrandr-providers expl $state_descr compadd -a provs && return 0
   ;;
 esac

--- a/Completion/X/Command/_xrandr
+++ b/Completion/X/Command/_xrandr
@@ -3,6 +3,12 @@
 local curcontext="$curcontext" state line expl
 typeset -A opt_args
 
+__xrandrproviders() {
+  local -a provs
+  provs=(${${(f)"$(xrandr --listproviders | tail +2)"}##*:})
+  _describe -t xrandrproviders 'providers' provs
+}
+
 _arguments -C \
   '(-d -display)'{-d,-display}':X display:_x_display' \
   '-help[display help]' \
@@ -47,7 +53,7 @@ _arguments -C \
   "*--addmode:output:->outputs:name" \
   "*--delmode:output:->outputs:name" \
   '--listproviders' \
-  '--setprovideroutputsource:provider: :source' \
+  '--setprovideroutputsource:*:provider: __xrandrproviders' \
   '--setprovideroffloadsink:provider: :sink' \
   '--listmonitors' \
   '--listactivemonitors' \


### PR DESCRIPTION
Not much magic happening, the output of `xrandr --listproviders` is used to suggest completions after `xrandr --setprovideroutputsource`. No experience from my side about `--setprovideroffloadsink` therefore I left it untouched.

AFAIU `--setprovideroutputsource` accepts multiple arguments (e.g. `xrandr --setprovideroutputsource modesetting  NVIDIA-0`, that's why I added the `*`. Unfortunately that means there is no completion for `--output` and alike anymore once one is after `--setprovideroutputsource`. That doesn't seem ideal to me, happy to hear other suggestions.