### PR TITLE
vcs_info-examples: optimize +vi-git-untracked()

### DIFF
--- a/Misc/vcs_info-examples
+++ b/Misc/vcs_info-examples
@@ -160,7 +160,7 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-untracked
 
 +vi-git-untracked(){
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' ]] && \
-        git status --porcelain | grep '??' &> /dev/null ; then
+        git status --porcelain | grep -q '^?? ' 2> /dev/null ; then
         # This will show the marker if there are any untracked files in repo.
         # If instead you want to show the marker only if there are untracked
         # files in $PWD, use:


### PR DESCRIPTION
Speed up the prompt on large and/or deep working directories by
stopping grep(1) as soon as it finds a single match, with `-q`.
Also, optimize the regular expression with an anchor and space.

Previously, +vi-git-untracked() waited for grep(1) to find all
matches of untracked files, redirecting them away to /dev/null,
before finally concluding that untracked files do indeed exist.