### PR TITLE
vcs_info-examples: optimize +vi-git-untracked()

### DIFF
--- a/Misc/vcs_info-examples
+++ b/Misc/vcs_info-examples
@@ -160,7 +160,7 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-untracked
 
 +vi-git-untracked(){
     if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' ]] && \
-        git status --porcelain | grep '??' &> /dev/null ; then
+        git status --porcelain | grep -q '^?? ' 2> /dev/null ; then
         # This will show the marker if there are any untracked files in repo.
         # If instead you want to show the marker only if there are untracked
         # files in $PWD, use:


### PR DESCRIPTION
Speed up the prompt on large and/or deep working directories by
stopping grep(1) as soon as it finds a single match, with `-q`.
Also, correct the regexp by adding a ^ anchor and increase its
specificity by accounting for the space in Porcelain Format v1.

Previously, +vi-git-untracked() waited for grep(1) to find all
matches of untracked files, redirecting them away to /dev/null,
before finally concluding that untracked files do indeed exist.

With this patch, I see 4x speedup on a large Git-enabled $HOME:

    $ time (git status --porcelain | wc -l)
    212
    0.01s user 0.02s system 0% cpu 9.021 total

    $ time (git status --porcelain | grep '??' &>/dev/null)
    0.01s user 0.02s system 0% cpu 12.294 total

    $ time (git status --porcelain | grep -q '^?? ' 2>/dev/null)
    0.01s user 0.01s system 0% cpu 3.097 total

Note that `-q` for grep(1) is in POSIX (IEEE Std 1003.1-2017):
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html

See discussion https://www.zsh.org/mla/workers/2021/msg01354.html