### PR TITLE
update options in apple's version of ssh-add

### DIFF
--- a/Completion/Unix/Command/_ssh
+++ b/Completion/Unix/Command/_ssh
@@ -81,18 +81,20 @@ _ssh () {
       '*:file:->file' "$common[@]" "$common_transfer[@]" && ret=0
     ;;
   ssh-add)
-    args=(
-      '-K[load resident keys from a FIDO authenticator]'
-    )
-    if [[ $OSTYPE == darwin* ]]; then 
-      [[ $APPLE_SSH_ADD_BEHAVIOR == "macos" ]] && args=(
+    if [[ $OSTYPE != darwin* || $APPLE_SSH_ADD_BEHAVIOR == openssh ]]; then
+      args=(
+        '-K[load resident keys from a FIDO authenticator]'
+      )
+    else
+      [[ ${APPLE_SSH_ADD_BEHAVIOR:-macos} == macos ]] && args=(
         '-A[add identities from keychain]'
         '-K[update keychain when adding/removing identities]'
-      ) || args+=(
-        '--apple-load-keychain[add identities from keychain]'
-        '--apple-use-keychain[update keychain when adding/removing identities]'
       )
-   fi
+    fi
+    [[ $OSTYPE == darwin* ]] && args+=(
+      '--apple-load-keychain[add identities from keychain]'
+      '--apple-use-keychain[update keychain when adding/removing identities]'
+    )
     _arguments -s : $args \
       '-c[identity is subject to confirmation via SSH_ASKPASS]' \
       '-D[delete all identities]' \

--- a/Completion/Unix/Command/_ssh
+++ b/Completion/Unix/Command/_ssh
@@ -81,10 +81,18 @@ _ssh () {
       '*:file:->file' "$common[@]" "$common_transfer[@]" && ret=0
     ;;
   ssh-add)
-    [[ $OSTYPE == darwin* ]] && args=(
-      '-A[add identities from keychain]'
-      '-K[update keychain when adding/removing identities]'
+    args=(
+      '-K[load resident keys from a FIDO authenticator]'
     )
+    if [[ $OSTYPE == darwin* ]]; then 
+      [[ $APPLE_SSH_ADD_BEHAVIOR == "macos" ]] && args=(
+        '-A[add identities from keychain]'
+        '-K[update keychain when adding/removing identities]'
+      ) || args+=(
+        '--apple-load-keychain[add identities from keychain]'
+        '--apple-use-keychain[update keychain when adding/removing identities]'
+      )
+   fi
     _arguments -s : $args \
       '-c[identity is subject to confirmation via SSH_ASKPASS]' \
       '-D[delete all identities]' \


### PR DESCRIPTION
ssh-add behavior has changed in newer macOS releases.
```
$ APPLE_SSH_ADD_BEHAVIOR= ssh-add -K
WARNING: The -K and -A flags are deprecated and have been replaced
         by the --apple-use-keychain and --apple-load-keychain
         flags, respectively.  To suppress this warning, set the
         environment variable APPLE_SSH_ADD_BEHAVIOR as described in
         the ssh-add(1) manual page.
...

$ APPLE_SSH_ADD_BEHAVIOR=openssh ssh-add -A
ssh-add: illegal option -- A
...

$ APPLE_SSH_ADD_BEHAVIOR=macos ssh-add -A
Identity Added: /path/to/key (keys comment)
...
```