### PR TITLE
_globquals: invert before/since for date glob qualifiers completion

### DIFF
--- a/Completion/Zsh/Type/_globquals
+++ b/Completion/Zsh/Type/_globquals
@@ -127,15 +127,15 @@ while [[ -n $PREFIX ]]; do
 	alts+=( "time-specifiers:time specifier:compadd -E 0 -d tdisp -S '' -a tmatch" )
       fi
       if ! compset -P '[-+]' && [[ -z $PREFIX ]]; then
-	sdisp=( before exactly since )
+	sdisp=( since exactly before )
 	smatch=( - '' + )
 	if zstyle -t ":completion:${curcontext}:senses" verbose; then
 	  zstyle -s ":completion:${curcontext}:senses" list-separator sep || sep=--
 	  default=" [default exactly]"
-	  sdisp=( "- $sep before" "+ $sep since" )
+	  sdisp=( "- $sep since" "+ $sep before" )
 	  smatch=( - + )
 	else
-	  sdisp=( before exactly since )
+	  sdisp=( since exactly before )
 	  smatch=( - '' + )
 	fi
         alts+=( "senses:sense${default}:compadd -E 0 -d sdisp -S '' -a smatch" )


### PR DESCRIPTION
The documentation says:

> Files accessed within the last n days are selected using a negative
> value for n (-n). Files accessed more than n days ago are selected
> by a positive n value (+n).

So, negative values are files since the selected date and positive
values are files before the selected days.