### PR TITLE
[completion] git push -o can be set multiple times.

### DIFF
--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -1465,7 +1465,7 @@ _git-push () {
     '(--no-signed --sign)--signed[GPG sign the push]' \
     "(--sign --signed)--no-signed[don't GPG sign the push]" \
     '--atomic[request atomic transaction on remote side]' \
-    '(-o --push-option)'{-o+,--push-option=}'[transmit string to server to pass to pre/post-receive hooks]:string' \
+    '*'{-o+,--push-option=}'[transmit string to server to pass to pre/post-receive hooks]:string' \
     '(-4 --ipv4 -6 --ipv6)'{-4,--ipv4}'[use IPv4 addresses only]' \
     '(-4 --ipv4 -6 --ipv6)'{-6,--ipv6}'[use IPv6 addresses only]' \
     ': :__git_any_repositories' \

--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -5664,7 +5664,7 @@ _git-send-pack () {
     "(--no-signed --signed)--sign=-[GPG sign the push]::signing enabled:(($^^sign))" \
     '(--no-signed --sign)--signed[GPG sign the push]' \
     "(--sign --signed)--no-signed[don't GPG sign the push]" \
-    '--push-option=[specify option to transmit]:option' \
+    '*--push-option=[specify option to transmit]:option' \
     '--progress[force progress reporting]' \
     '--thin[send a thin pack]' \
     '--atomic[request atomic transaction on remote side]' \


### PR DESCRIPTION
From [the git-push docs](https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt) I understand that `-o` can be provided multiple times. This also matches the usage examples [by gitlab](https://docs.gitlab.com/ee/user/project/push_options.html).