### PR TITLE
replace every occurrence of replace_string

### DIFF
--- a/Functions/Misc/zargs
+++ b/Functions/Misc/zargs
@@ -291,7 +291,7 @@ do
 	args=( "${(@)argv[1,end]}" )
 	shift $((end > ARGC ? ARGC : end))
 	if (( $#i ))
-	then call=( "${(@)command/$i/$args}" )
+	then call=( "${(@)command//$i/$args}" )
 	else call=( "${(@)command}" "${(@)args}" )
 	fi
 	if (( ${(c)#call} > s ))


### PR DESCRIPTION
`zargs -i{} -- hi -- echo "{} and {} is okay"` will output 'hi and {} is okay'
with the change will output 'hi and hi is okay'