### PR TITLE
[Completion] apply compadd replacements during prefix replacement in _canonical_paths (for `umount`)

### DIFF
--- a/Completion/Unix/Type/_canonical_paths
+++ b/Completion/Unix/Type/_canonical_paths
@@ -42,7 +42,13 @@ _canonical_paths_add_paths () {
     # ### Ideally, this codepath would do what the 'if' above does,
     # ### but telling compadd to pretend the "word on the command line"
     # ### is ${"the word on the command line"/$origpref/$canpref}.
-    matches+=(${${(M)files:#$canpref*}/$canpref/$origpref})
+    () {
+      local -a tmp_buffer tmp_buffer2
+      tmp_buffer=(${${(M)files:#$canpref*}/$canpref/$origpref})
+      compadd -A tmp_buffer2 "$__gopts[@]" -a tmp_buffer
+      matches+=($tmp_buffer2)
+    }
+    # matches+=(${${(M)files:#$canpref*}/$canpref/$origpref})
   fi
 
   for subdir in $expref?*(@); do


### PR DESCRIPTION
NB: marked as draft because a) the comment needs to be cleaned up but also because b) this is merely parts of the file copied together, i don't see a more elegant way right now, but suspect maintainers will either know which way to go, or have reservations against merging how i copied it together. In any case this is related to an issue (see below) and I went ahead to with patching it up for my local usage.

# issue
USB sticks can have white spaces in their device names (might be used on windows, they get handed around, so whoever mounts them might not be whoever named it). In my case a stick I used was just called "USB DISK". The stick gets automounted (by udiskie, but i suspect it's common to auto mount USB sticks and use the device name) to `/media/pseyfert/USB DISK`.

When tab completing `umount ⇥` from anywhere the tab completions contain correctly `/media/pseyfert/USB\ DISK` (that is, the white space gets escaped. When changing to `/media/pseyfert`, the completions for `umount` still contain the mount point with absolute path, but in addition the relative path `USB DISK` (this time, it gets entered like that, without escaping the white space).

# my change
I traced down that `umount` gets completed by `_mount` which calls `_umountable` which calls `_canonical_paths` and in there, there is the `if` which detects if prefix replacement should happen. in case of umount, `files` contains the mount points without escape symbols, the "then" applies various replacements (as specified by _umountable) and escapes the white space. The else does prefix replacment but does not do (as indicated by the comment) the `-M` replacement. The `-M` replacement is (I think) irrelevant for me here, but `compadd` in the "then" also takes care of escaping white spaces.