### PR TITLE
[completion] Update _tmux definition using a recent build of tmux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-02-18  Matt Koscica <matt.koscica@gmail.com>
+
+	* github PR #87: Completion/Unix/Command/_tmux: update options
+	for tmux 3.4
+
 2022-02-16  Jun-ichi Takimoto  <takimoto-j@kba.biglobe.ne.jp>
 
 	* 49757 (sourceforge #1): samcarter: Completion/Unix/Command/_tex:

--- a/Completion/Unix/Command/_tmux
+++ b/Completion/Unix/Command/_tmux
@@ -130,6 +130,8 @@ _tmux_aliasmap=(
     popup       display-popup
 
     # buffers
+    clearphist  clear-prompt-history
+    showphist   show-prompt-history
     clearhist   clear-history
     deleteb     delete-buffer
     lsb         list-buffers
@@ -267,6 +269,11 @@ _tmux-clear-history() {
   _arguments '-t+[specify target pane]:pane:__tmux-panes'
 }
 
+_tmux-clear-prompt-history() {
+  [[ -n ${tmux_describe} ]] && print "remove history of values for command line prompts" && return
+  _arguments '-T+[specify prompt type]'
+}
+
 _tmux-clock-mode() {
   [[ -n ${tmux_describe} ]] && print "enter clock mode" && return
   _arguments '-t+[specify target pane]:pane:__tmux-panes'
@@ -388,13 +395,19 @@ _tmux-display-panes() {
 _tmux-display-popup() {
   [[ -n ${tmux_describe} ]] && print "display a popup box over a pane" && return
   _arguments -s \
+    '-B[do not surround the popup by a border]' \
     '-C[close any popup on the client]' \
     '-c+[specify target client]:client:__tmux-clients' \
     '-d+[specify working directory for the command]:directory:_directories' \
+    '*-e[specify environment variable]:environment variable:_parameters -g "*export*" -qS=' \
     '-E[close the popup when the command exits]' \
+    '-EE[only close the popup when the command exits successfully]' \
     '-w+[specify width]:width' \
     '-h+[specify height]:height' \
+    '-s+[specify the style for the popup]:style:__tmux-style' \
+    '-S+[specify the style for the popup border]:style:__tmux-style' \
     '-t+[specify target pane]:pane:__tmux-panes' \
+    '-T[specify popup title (supports formats)]:format:__tmux-formats' \
     '-x+[specify horizontal position]:position' \
     '-y+[specify vertical position]:position' \
     ':shell command:_cmdstring'
@@ -865,6 +878,10 @@ _tmux-send-prefix() {
     '-t+[specify target pane]:pane:__tmux-panes'
 }
 
+# NOTE: this is actually an alias for "show-messages -JT", but until the
+# aliasmap system in check-tmux-state can properly handle aliases which are
+# more complex than a single word, it's best to leave this here.
+
 _tmux-server-info() {
   [[ -n ${tmux_describe} ]] && print "show server information" && return
   __tmux-nothing-else
@@ -1039,6 +1056,11 @@ _tmux-show-options() {
   fi
   __tmux-options-complete ${mode} ${state} && ret=0
   return ret
+}
+
+_tmux-show-prompt-history() {
+  [[ -n ${tmux_describe} ]] && print "show status prompt history" && return
+  _arguments '-T+[specify prompt type]'
 }
 
 _tmux-show-window-options() {
@@ -1530,7 +1552,6 @@ function __tmux-option-guard() {
             'status-right-style:__tmux-style'
             'status-style:__tmux-style'
             'update-environment:MSG:string listing env. variables'
-            'user-keys:MSG:key'
             'visual-activity:DESC:on off'
             'visual-bell:DESC:on off'
             'visual-silence:DESC:on off'
@@ -1549,6 +1570,7 @@ function __tmux-option-guard() {
             'message-limit:'${int_guard}
             'set-clipboard:DESC:on off'
             'terminal-overrides:MSG:overrides string'
+            'user-keys:MSG:key'
         )
     else
         options=(
@@ -1643,6 +1665,8 @@ function __tmux-session-options() {
         'set-titles-string:format used by set-titles'
         'silence-action:set action on window silence when monitor-silence is on'
         'status:show or hide the status bar'
+        'status-bg:set the background style used by the status bar'
+        'status-fg:set the foreground style used by the status bar'
         'status-format:specify the format to be used for each line of the status line'
         'status-interval:interval (in seconds) for status bar updates'
         'status-justify:position of the window list in status bar'
@@ -1656,7 +1680,6 @@ function __tmux-session-options() {
         'status-right-style:style of right part of status line'
         'status-style:style status line'
         "update-environment:list of variables to be copied to a session's environment"
-        'user-keys:set list of user-defined key escape sequences'
         'visual-activity:display status line messages upon activity'
         'visual-bell:use visual bell instead of audible'
         'visual-silence:print a message if monitor-silence is on'
@@ -1701,20 +1724,28 @@ function __tmux-panes() {
     fi
 }
 
+
 function __tmux-server-options() {
     local -a tmux_server_options
     tmux_server_options=(
+        'backspace:set key sent by tmux for backspace'
         'buffer-limit:number of buffers kept per session'
         'command-alias:custom command aliases'
+        'copy-command:specify the default command when "copy-pipe" is called without arguments'
         'default-terminal:default terminal definition string'
         'escape-time:set timeout to detect single escape characters (in msecs)'
+        'editor:specify the command used when tmux runs an editor'
         'exit-unattached:make server exit if it has no attached clients'
         'exit-empty:exit when there are no active sessions'
+        'extended-keys:controls whether tmux will send extended keys through to the terminal'
         'focus-events:request focus events from terminal'
         'history-file:tmux command history file name'
         'message-limit:set size of message log per client'
+        'prompt-history-limit:sets the number of history items to save in the history file'
         'set-clipboard:use esc sequences to set terminal clipboard'
+        'terminal-features:set terminal features not detected by terminfo'
         'terminal-overrides:override terminal descriptions'
+        'user-keys:set list of user-defined key escape sequences'
     )
     _describe -t tmux-server-options 'tmux server option' tmux_server_options
 }
@@ -1770,10 +1801,15 @@ function __tmux-window-options() {
         'aggressive-resize:aggressively resize windows'
         'allow-rename:allow programs to change window titles'
         'alternate-screen:allow alternate screen feature to be used'
-        'automatic-rename:attempt to automatically rename windows'
         'automatic-rename-format:format for automatic renames'
+        'automatic-rename:attempt to automatically rename windows'
         'clock-mode-colour:set clock colour'
         'clock-mode-style:set clock hour format (12/24)'
+        'copy-mode-current-match-style:set the style of the current search match in copy mode'
+        'copy-mode-mark-style:set the style of the line containing the mark in copy mode'
+        'copy-mode-match-style:sets the style of search matches in copy mode'
+        'cursor-colour:sets the colour of the cursor'
+        'cursor-style:sets the style of the cursor'
         'main-pane-height:set height for main-* layouts'
         'main-pane-width:set width for main-* layouts'
         'mode-keys:mode to use in copy and choice modes (vi/emacs)'
@@ -1786,11 +1822,18 @@ function __tmux-window-options() {
         'pane-active-border-style:style of border of active pane'
         'pane-base-index:integer at which to start indexing panes'
         'pane-border-format:set pane border format string'
+        'pane-border-indicators:set the indicator style for the active pane in a two pane split'
+        'pane-border-lines:sets the type of characters used for drawing pane borders'
         'pane-border-status:turn border status off or set its position'
         'pane-border-style:style of border pane'
+        "pane-colours:an array used to configure tmux's colour palette"
+        'popup-border-lines:set the type of line used to draw popup borders'
+        "popup-border-style:set the style for the popup's border"
+        'popup-style:set the popup style'
         "remain-on-exit:don't destroy windows after the program exits"
         'synchronize-panes:send input to all panes of a window'
         'window-active-style:style of active window'
+        'window-size:indicate how to automatically size windows'
         'window-status-activity-style:style of status bar activity tag'
         'window-status-bell-style:style of status bar bell tag'
         'window-status-current-format:set status line format for active window'
@@ -1799,7 +1842,6 @@ function __tmux-window-options() {
         'window-status-last-style:style of last window in status bar'
         'window-status-separator:separator drawn between windows in status line'
         'window-status-style:general status bar style'
-        'window-size:indicate how to automatically size windows'
         'window-style:style of window'
         'wrap-search:search wrap around at the end of a pane'
         'xterm-keys:generate xterm-style function key sequences'

--- a/Util/check-tmux-state
+++ b/Util/check-tmux-state
@@ -74,18 +74,18 @@ available_aliases=( $( $tmux list-commands |
 # Gather information about options:
 typeset -a supported_session_options
 supported_session_options=( ${"${tmux_session_options[@]}"%%:*} )
-typeset -a available_session_options
-available_session_options=( $( $tmux show-options -g | cut -f1 -d' ' ) )
+typeset -aU available_session_options
+available_session_options=( ${${(f)"$($tmux show-options -g | grep -v '^@')"}%%(\[<->\])# *} )
 
-typeset -a available_server_options
-supported_server_options=( ${"${tmux_server_options[@]}"%%:*} )
 typeset -a supported_server_options
-available_server_options=( $( $tmux show-options -s -g | cut -f1 -d' ' ) )
+supported_server_options=( ${"${tmux_server_options[@]}"%%:*} )
+typeset -aU available_server_options
+available_server_options=( ${${(f)"$($tmux show-options -s -g | grep -v '^@')"}%%(\[<->\])# *} )
 
 typeset -a supported_window_options
 supported_window_options=( ${"${tmux_window_options[@]}"%%:*} )
-typeset -a available_window_options
-available_window_options=( $( $tmux show-options -w -g | cut -f1 -d' ' ) )
+typeset -aU available_window_options
+available_window_options=( ${${(f)"$($tmux show-options -w -g | grep -v '^@')"}%%(\[<->\])# *} )
 
 typeset -a supported available
 


### PR DESCRIPTION
Using the tool [`zsh.git:Util/check-tmux-state`](https://github.com/zsh-users/zsh/blob/master/Util/check-tmux-state), I have generated some updates for [tmux completion in zsh](https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_tmux). This also required some minor tweaks to the tool itself.

The update was based off tmux.git revision [c67abcf8182b](https://github.com/tmux/tmux/commit/c67abcf8182b3a4e4c1e71b370c814a65c12a46c).

Most updates were simple to apply, however, there is some oddness related to the `server-info` and `info` commands due to changes in tmux, in order to enable dynamic aliases. As of tmux.git commit [126d364abe2e8c063efa5a888de69](https://github.com/tmux/tmux/commit/126d364abe2e8c063efa5a888de6997ca05641fc), `server-info` is no longer a command, and both `server-info` and its existing alias `info` are now defined as a `command-alias` for `show-messages -JT`.

`check-tmux-state` assumes that aliases are listed in the output of `tmux list-commands` and nowhere else, and so [creates `$available_aliases` by looking for alias names enclosed in parens](https://github.com/zsh-users/zsh/blob/master/Util/check-tmux-state#L70):
```
% grep -A2 'available_aliases=' Util/check-tmux-state
available_aliases=( $( $tmux list-commands |
                       grep '^[a-z-]* *(' |
                       gsed -e 's,^\([a-z-]*\) *(\([a-z-]*\))\(.*\)$,\2 \1,' ) )
# splitw -> split-window
% tmux list-commands| grep ^split
split-window (splitw) [-bdefhIPvZ] [-c start-directory] [-e environment] [-F format] [-l size] [-t target-pane][shell-command]
```

But, it's now also necessary to update `$available_aliases` based on the `command-alias` entries in tmux's server options:
```
# dynamic alias config:
% tmux show-options -s command-alias | egrep info
command-alias[2] "server-info=show-messages -JT"
command-alias[3] "info=show-messages -JT"
```

...and this can't be done (easily) by using the existing code, as it's not possible for zsh to use a hyphenated token like `server-info` as a key in an associative array AFAICT. Attempting to add such an item results either in a silent error, or alternatively, a bad subscript error.

This will also affect the usage of `zstyle`. The `_tmux` completion file suggests that completion output for tmux can be restricted to commands only (or aliases only), with a line such as the following:
```
#       % zstyle ':completion:*:*:tmux:*:subcommands' mode 'commands'
```
If a user chooses to use this technique to enable commands only, then important aliases such as server-info will no longer be visible to the user.