### PR TITLE
fix and extend htop completions

### DIFF
--- a/Completion/Linux/Command/_htop
+++ b/Completion/Linux/Command/_htop
@@ -1,11 +1,15 @@
 #compdef htop
 
 _arguments -S : \
-  '(-d --delay)'{-d+,--delay=}'[update frequency]:duration (tenths of seconds)' \
   '(-C --no-color --no-colour)'{-C,--no-colo{,u}r}'[monochrome mode]' \
+  '(-d --delay)'{-d+,--delay=}'[Set the delay between updates]:duration (tenths of seconds)' \
+  '(-F --filter)'{-F+,--Filter=}'[Show only the commands matching the given filter]' \
   '(-)'{-h,--help}'[display usage information]' \
+  '(M --no-mouse)'{-M,--no-mouse}'[Disable the mouse]' \
   \*{-p+,--pid=}'[show given pids]: : _sequence -n ${$(</proc/sys/kernel/pid_max)\:-32768} _pids' \
   '(-s --sort-key)'{-s+,--sort-key=}'[sort by key]:key:( ${(f)"$(_call_program sort-keys $words[1] --sort-key help)"} )' \
-  '(-t --tree)'{-t,--tree}'[show tree view of processes]' \
+  '(-t --tree)'{-t,--tree}'[show tree view (can be combined with -s)]' \
   '(-u --user)'{-u+,--user=}'[show processes of user]: : _users' \
-  '(-)'{-v,--version}'[display version information]'
+  '(-U --no-unicode)'{-U,--no-unicode}'[Do not use unicode but plain ASCII]' \
+  '--readonly''[Disable all system and process changing features]' \
+  '(-)'{-V,--version}'[Print version information]'


### PR DESCRIPTION
I noticed htop was suggesting -v for --version but it should be -V .  (Checked on alpine, fedora, nixos and ubuntu)
Also added some missing options based on htop --help .

I actually don't know how to write completion files but tested the changes. Feel free to make any changes or ignore the pull request and copy to master directly.