### PR TITLE
Replace /etc/mtab with /proc/self/mounts for Linux

### DIFF
--- a/Completion/Linux/Command/_btrfs
+++ b/Completion/Linux/Command/_btrfs
@@ -424,7 +424,7 @@ while (( $#state )); do
     ;;
     mounts)
       _wanted mount-points expl 'mount point' compadd \
-          ${${${(M)${(f)"$(</etc/mtab)"}:#*btrfs*}#* }%% *} && ret=0
+          ${${${(M)${(f)"$(</proc/self/mounts)"}:#*btrfs*}#* }%% *} && ret=0
     ;;
     filters)
       state=()

--- a/Completion/Linux/Command/_fusermount
+++ b/Completion/Linux/Command/_fusermount
@@ -19,7 +19,7 @@ case "$state" in
   if [[ $+opt_args[-u] -eq 0 ]]; then
     _files -/
   else
-    mtpts=(${${${"${(f)$(< /etc/mtab)}"}#* }%% *})
+    mtpts=(${${${"${(f)$(< /proc/self/mounts)}"}#* }%% *})
     _canonical_paths mounted 'mounted filesystem' "${(@g::)mtpts}"
   fi
   ;;

--- a/Completion/Unix/Type/_umountable
+++ b/Completion/Unix/Type/_umountable
@@ -3,7 +3,12 @@ local tmp
 local dev_tmp dpath_tmp mp_tmp mline
 
 case "$OSTYPE" in
-linux*|irix*)
+linux*)
+  tmp=( "${(@f)$(< /proc/self/mounts)}" )
+  dev_tmp=( "${(@)${(@)tmp%% *}:#none}" )
+  mp_tmp=( "${(@)${(@)tmp#* }%% *}" )
+  ;;
+irix*)
   tmp=( "${(@f)$(< /etc/mtab)}" )
   dev_tmp=( "${(@)${(@)tmp%% *}:#none}" )
   mp_tmp=( "${(@)${(@)tmp#* }%% *}" )


### PR DESCRIPTION
/proc/self/mounts has been available since Linux 2.4.19,
released in 2002. /etc/mtab is usually a symlink to this
file but might not exist.

Not sure how to deal with irix, should this just fallback to the default?