### PR TITLE
Add completions for neomutt

### DIFF
--- a/Completion/Unix/Command/_mutt
+++ b/Completion/Unix/Command/_mutt
@@ -1,4 +1,4 @@
-#compdef mutt
+#compdef mutt neomutt
 
 _arguments -s -S \
   '::recipient:_email_addresses -n mutt' \


### PR DESCRIPTION
BTW, about <https://github.com/msys2/MSYS2-packages/issues/2965>, any method to
make zsh know cygwin's (or msys) start is not unix's start? Thanks.
