### PR TITLE
fix completion for zpool upgrade

### DIFF
--- a/Completion/Unix/Command/_zfs
+++ b/Completion/Unix/Command/_zfs
@@ -1269,7 +1269,7 @@ case $service:$words[1] in
 
   zpool:upgrade)
     _arguments -A "-*" -S \
-      '(- *)-v[display ZFS versions and descriptions]'
+      '(- *)-v[display ZFS versions and descriptions]' \
       "(-v)-V+[upgrade to given version]:version" \
       '(-v *)-a[upgrade all pools]' \
       '(-a -v)*:pool:_zfs_pool'


### PR DESCRIPTION
There was a backslash missing for the completion of `zpool upgrade` which this PR adds!
Fixes the following error:
```
$ zpool upgrade _zfs:1239: command not found: (-v)-V+[upgrade to given version]:version
-v
```