### PR TITLE
cd: Append 2nd argument to CWD if 1st is empty

### DIFF
--- a/Doc/Zsh/builtins.yo
+++ b/Doc/Zsh/builtins.yo
@@ -287,7 +287,8 @@ directory hash table.
 
 The second form of tt(cd) substitutes the string var(new)
 for the string var(old) in the name of the current directory,
-and tries to change to this new directory.
+and tries to change to this new directory. If var(old) is empty, var(new)
+is appended to the name of the current directory.
 
 The third form of tt(cd) extracts an entry from the directory
 stack, and changes to that directory.  An argument of the form

--- a/Src/builtin.c
+++ b/Src/builtin.c
@@ -921,6 +921,8 @@ cd_get_dest(char *nam, char **argv, int hard, int func)
 	}
 	len1 = strlen(argv[0]);
 	len2 = strlen(argv[1]);
+	if (!len1)
+	    u = pwd + strlen(pwd);
 	len3 = u - pwd;
 	d = (char *)zalloc(len3 + len2 + strlen(u + len1) + 1);
 	strncpy(d, pwd, len3);


### PR DESCRIPTION
In cd's second form:

```
cd [ -qsLP ] old new
```

Currently when old is empty, cd will prepend new to the name of the current directory. As this has very limited use cases (e.g. `cd '' /proc` when in `/sys/...`), change the behaviour of cd to **append** new instead.