### PR TITLE
Fix a typo

### DIFF
--- a/Completion/Linux/Command/_valgrind
+++ b/Completion/Linux/Command/_valgrind
@@ -165,7 +165,7 @@ args_massif=(
   "--time-unit=-[specify time unit]:unit [i]:((
     i\:instructions\ executed
     ms\:milliseconds
-    b\:heap\ bytes\ alloc\'d/dealloc\'d
+    B\:heap\ bytes\ alloc\'d/dealloc\'d
   ))"
   '--detailed-freq=-[every Nth snapshot should be detailed]:snapshot interval [10]'
   '--max-snapshots=-[specofy maximum number of snapshots recorded]:maximum [100]'


### PR DESCRIPTION
$ valgrind --tool=massif --help | grep time-unit
    --time-unit=i|ms|B        time unit: instructions executed, milliseconds
