### PR TITLE
Fixed incorrect completion for `dnf --showduplicates`

### DIFF
--- a/Completion/Redhat/Command/_dnf
+++ b/Completion/Redhat/Command/_dnf
@@ -245,7 +245,7 @@ _dnf() {
     '--security[include security relevant packages]'
     '*--setopt=[override config option]:repoid.option=value: '
     '--skip-broken[resolve depsolve problems by skipping packages]'
-    '--show-duplicates[show duplicate packages in repos]'
+    '--showduplicates[show duplicate packages in repos]'
     '(-v --verbose)'{-v,--verbose}'[set verbose, show debug messages]'
     '(- *)--version[show dnf version]'
     '(-y --assumeyes --assumeno)'{-y,--assumeyes}'[answer yes for all questions]'


### PR DESCRIPTION
The zsh completion for dnf's `--showduplicates` flag is incorrectly listed as `--show-duplicates`

![image](https://github.com/zsh-users/zsh/assets/48618519/2d16ea72-8347-4b53-82ca-ebe6d1939880)
