### PR TITLE
remote files completion: remove double-escaping

### DIFF
--- a/Completion/Unix/Type/_remote_files
+++ b/Completion/Unix/Type/_remote_files
@@ -60,10 +60,7 @@ if zstyle -T ":completion:${curcontext}:files" remote-access; then
     dirprefix=${dir}/
   fi
 
-  if [[ -z $QIPREFIX ]]
-    then rempat="${dirprefix}${PREFIX%%[^./][^/]#}\*"
-    else rempat="${dirprefix}${(q)PREFIX%%[^./][^/]#}\*"
-  fi
+  rempat="${dirprefix}${(q)PREFIX%%[^./][^/]#}\*"
 
   # remote filenames
   remfiles=(${(M)${(f)"$(
@@ -92,9 +89,9 @@ if zstyle -T ":completion:${curcontext}:files" remote-access; then
   while _tags; do
     while _next_label remote-files expl ${suf:-remote directory}; do
       [[ -n $suf ]] &&
-          compadd "$args[@]" "$expl[@]" -d remdispf -- ${(q)remdispf%[*=|]} && ret=0
+          compadd "$args[@]" "$expl[@]" -d remdispf -- ${remdispf%[*=|]} && ret=0
       compadd ${suf:+-S/} $autoremove "$args[@]" "$expl[@]" -d remdispd \
-	-- ${(q)remdispd%/} && ret=0
+	-- ${remdispd%/} && ret=0
     done
     (( ret )) || return 0
   done


### PR DESCRIPTION
Removes the double escaping in the remote files completion. This affects rsync and scp. Instead of for example a space character in a remote filename turning into `\\\ `, it will now correctly turn into `\ `. While scp apparently works with either one, rsync supports only the latter since version [3.2.4](https://download.samba.org/pub/rsync/NEWS#3.2.4). This has been a problem for almost two years now.

For more context, see the corresponding issue from fish-shell: https://github.com/fish-shell/fish-shell/issues/8895