### PR TITLE
completion(ruby): completor opts for irb

### DIFF
--- a/Completion/Unix/Command/_ruby
+++ b/Completion/Unix/Command/_ruby
@@ -89,6 +89,8 @@ irb=(
   "(--colorize)--nocolorize[don't use color-highlighting]"
   '(--noautocomplete)--autocomplete[use auto-completion]'
   "(--autocomplete)--noautocomplete[don't use auto-completion]"
+  '(--regexp-completor)--type-completor[use regexp based completion]'
+  '(--type-completor)--regexp-completor[use type based completion]'
   '(--noscript)--script[script mode]'
   '(--script)--noscript[no script mode]'
   '--single-irb[share self with sub-irb]'


### PR DESCRIPTION
IRB now has `--regexp-completor` and `--type-completor` options added by: https://github.com/ruby/irb/commit/1dec2708c92559487e51c5f3a3030b74a62270e5