### PR TITLE
Fix copy-earlier-word handling of numeric arguments

### DIFF
--- a/Functions/Zle/copy-earlier-word
+++ b/Functions/Zle/copy-earlier-word
@@ -11,7 +11,7 @@ setopt typesetsilent
 typeset -g __copyword
 if (( ${NUMERIC:-0} )); then
   # 1 means last word, 2 second last, etc.
-  (( __copyword = ${NUMERIC:-0} ))
+  (( __copyword = -${NUMERIC:-0} ))
   zstyle -s :$WIDGET widget __copywidget
 elif [[ -n $__copyword && $WIDGET = $LASTWIDGET ]]; then
   (( __copyword-- ))


### PR DESCRIPTION
As mentioned in the comment:

```zsh
  # 1 means last word, 2 second last, etc.
```

the numeric argument is supposed to be interpreted as an offset from the end.

The intended behavior is a lot more useful than the current behavior