### PR TITLE
Fix completion for git bisect visualize

### DIFF
--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -278,6 +278,7 @@ _git-bisect () {
           _arguments -C -s \
             $log_options \
             $revision_options && ret=0
+          ;;
         (*)
           _nothing
           ;;


### PR DESCRIPTION
When trying to use the completion for git bisect visualize one currently is greeted with the curious error of something like this:

    git bisect visualize _git-bisect:89: command not found: arch

While in this case 'arch' is the name of the first folder in the directory. The cause for this is a missing separation of switch cases which we fix by inserting the needed ";;".

---

In my opinion this is a potentially really nasty bug (although people are unlikely to hit it) since it executes arbitrary binaries depending on the folder the completion is used in.
See the following demonstration:



https://github.com/zsh-users/zsh/assets/26827864/7d16ff71-7a33-4f2a-a7f7-a4e0a171d1cb


