### PR TITLE
Update _git to reflect `--recursive` being an alias

### DIFF
--- a/Completion/Unix/Command/_git
+++ b/Completion/Unix/Command/_git
@@ -664,7 +664,7 @@ _git-clone () {
     '(--single-branch)--no-single-branch[clone history leading up to each branch]' \
     "--no-tags[don't clone any tags and make later fetches not follow them]" \
     '--shallow-submodules[any cloned submodules will be shallow]' \
-    '--recursive[initialize all contained submodules]' \
+    '--recursive[initialize submodules in the clone]' \
     '(--recursive --recurse-submodules)'{--recursive,--recurse-submodules}'=-[initialize submodules in the clone]::file:__git_files' \
     '--separate-git-dir[place .git dir outside worktree]:path to .git dir:_path_files -/' \
     \*--server-option='[send specified string to the server when using protocol version 2]:option' \


### PR DESCRIPTION
`--recursive` and `--recurse-submodules` are aliased according to https://github.com/git/git/blob/99c33bed562b41de6ce9bd3fd561303d39645048/builtin/clone.c#L105