### PR TITLE
Completion: Add make variables with values

### DIFF
--- a/Completion/Unix/Command/_make
+++ b/Completion/Unix/Command/_make
@@ -76,7 +76,8 @@ _make-parseMakefile () {
     case "$input " in
       # VARIABLE = value OR VARIABLE ?= value
       ([[:alnum:]][[:alnum:]_]#[" "$TAB]#(\?|)=*)
-      var=${input%%[ $TAB]#(\?|)=*}
+      var=${input%%[ $TAB]}
+      var=${input%:}
       val=${input#*=}
       val=${val##[ $TAB]#}
       VARIABLES[$var]=$val
@@ -85,7 +86,8 @@ _make-parseMakefile () {
       # VARIABLE := value OR VARIABLE ::= value
       # Evaluated immediately
       ([[:alnum:]][[:alnum:]_]#[" "$TAB]#:(:|)=*)
-      var=${input%%[ $TAB]#:(:|)=*}
+      var=${input%%[ $TAB]}
+      var=${input%:}
       val=${input#*=}
       val=${val##[ $TAB]#}
       val=$(_make-expandVars $val)
@@ -132,7 +134,8 @@ _make-parseDataBase () {
         skip=1  # skip next line
         ;;
       ([[:alnum:]][[:alnum:]_]#[" "$TAB]#(\?|:|::|)=*)
-        var=${input%%[ $TAB]#(\?|:|::|)=*}
+        var=${input%%[ $TAB]}
+        var=${input%:}
         VARIABLES[$var]=1
         ;;
       ([[*?[:alnum:]$][^$TAB:=%]#:[^=]*)
@@ -292,7 +295,7 @@ _make() {
     else
       _alternative \
         'targets:make target:compadd -Q -a TARGETS' \
-        'variables:make variable:compadd -S = -F keys -k VARIABLES' \
+        'variables:make variable:compadd -F keys -k VARIABLES' \
         '*:file:_files -W $basedir' && ret=0
     fi
   esac


### PR DESCRIPTION
So far only variable names were added. However Makefiles and make would also return possible values which are not completed so far. The values are stored and overwritten in the map without using them anywhere. So instead it currently makes more sense to complete the whole variable name-value combination instead of only the name.

I'm unsure about this change because I have not completely understood zsh's completion system yet. However it works for me (version 5.8 and call-command set true) as I want it to be. It's similar to bash's behavior with that.