### PR TITLE
Make okular's completion support *.epub files.

### DIFF
--- a/Completion/X/Command/_okular
+++ b/Completion/X/Command/_okular
@@ -1,7 +1,7 @@
 #compdef okular
 local extns
 
-extns="(pdf|ps|eps|dvi)(|.gz|.bz2)|djvu|tif|tiff|chm|cbr|cbz"
+extns="(pdf|ps|eps|dvi)(|.gz|.bz2)|djvu|tif|tiff|chm|cbr|cbz|epub"
 
 _arguments \
   '(-p --page)'{-p,--page}'[page of the document to be shown]:page: ' \


### PR DESCRIPTION
I checked that okular opens *.epub files. At least on Fedora Linux 41beta x86-64.