### PR TITLE
_dpkg: remove --largemem, --smallmem options

### DIFF
--- a/Completion/Debian/Command/_dpkg
+++ b/Completion/Debian/Command/_dpkg
@@ -64,8 +64,6 @@ _dpkg_options=(
   '(--skip-same-version -E)'{--skip-same-version,-E}'[skip packages with same version as installed]'
   '(--refuse-downgrade -G)'{--refuse-downgrade,-G}'[skip packages with earlier version than installed]'
   '(--auto-deconfigure -B)'{--auto-deconfigure,-B}'[install can break other packages]'
-  '--largemem[optimize for >4Mb RAM]'
-  '--smallmem[optimize for <4Mb RAM]'
   '--no-act[show potential actions but do not follow through]'
   '-D+[debug options]:debug options:(h 1 2 3)'
   '--debug=[debug options]:debug options:(help 1 2 3)'


### PR DESCRIPTION
These options were deleted in 2009:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468106

If desired I'd be happy to add a version condition, but it seems spurious in this case.