### PR TITLE
Add completion for irb --no-pager

### DIFF
--- a/Completion/Unix/Command/_ruby
+++ b/Completion/Unix/Command/_ruby
@@ -69,6 +69,7 @@ irb=(
   $opts[(r)*-d\[*]
   '(--noinspect)--inspect[use inspect for output]'
   "(--inspect)--noinspect[don't use inspect for output]"
+  "--no-pager[don't use pager]"
   '(--prompt --prompt-mode --inf-ruby-mode --simple-prompt --noprompt)'{--prompt=,--prompt-mode=}'[switch prompt mode]:prompt mode:(default classic simple inf-ruby xmp null)'
   '(--prompt --prompt-mode --inf-ruby-mode --simple-prompt --noprompt)'{--inf-ruby-mode,--simple-prompt,--noprompt}
   '--tracer[display trace for each command execution]'


### PR DESCRIPTION
irb has `--no-pager` since https://github.com/ruby/irb/commit/df1c3b904284c4ec36924ca6deab2bcefc371eb1.