### PR TITLE
fix _gpg completion

### DIFF
--- a/Completion/Unix/Command/_gpg
+++ b/Completion/Unix/Command/_gpg
@@ -29,7 +29,7 @@ fi
   '(-c --symmetric)'{-c,--symmetric}'[encrypt with symmetric cipher only]'
   '(-s --sign)'{-s,--sign}'[make a signature]'
   '*'{-r+,--recipient}'[specify user to encrypt for]:recipient:->public-keys'
-  '(-u --local-user)'{-u+,--local-user}'[use name as the user ID to sign]:user attachment:_users'
+  '(-u --local-user)'{-u+,--local-user}'[use name as the user ID to sign]:key:->secret-keys'
   '(-o --output)'{-o+,--output}'[write output to file]:output file:_files'
   '(-h --help)'{-h,--help}'[display usage information]'
   '--version[print info on program version and supported algorithms]'
@@ -238,7 +238,11 @@ case "$state" in
       parts=("${(@s.:.)secret_keys_lines[$i]}")
       if [[ ${parts[1]} == "fpr" ]]; then
         current_uid="${parts[10]}"
-        i=$((i + 1))
+        until [[ "${${(@s.:.)secret_keys_lines[$i]}[1]}" == "uid" ]] || [[ "${i}" -ge "${#secret_keys_lines[@]}" ]]; do
+          # it can be "grp" or other tokens.
+          # Let's iterate until we found "uid" or face an end of secret keys array
+          i=$((i + 1))
+        done
         parts=("${(@s.:.)secret_keys_lines[$i]}")
         while [[ ${parts[1]} == "uid" ]]; do
           uids+=("${current_uid}")


### PR DESCRIPTION
1) THe completion of `--local-user` wass irrelevant: it completed system users, while gpg expects private keys IDs

2) `secret-keys` completion was also broken and completed nothing. The reason of that to happen was in that fact that it assumed `uid` token would be next after `fpr` (same as it do in public-keys completion), while in current gnupg versions there is at least `grp` token, and potentially can be others. So, instead i+=2 I made `until "uid"` loop.