### PR TITLE
53449: do not complete indices for empty array subscripts

### DIFF
--- a/Completion/Zsh/Context/_subscript
+++ b/Completion/Zsh/Context/_subscript
@@ -98,6 +98,9 @@ elif [[ ${(Pt)${compstate[parameter]}} = array* ]]; then
   while _tags; do
     if _requested indexes; then
       ind=( {1..${#${(P)${compstate[parameter]}}}} )
+      if [[ ${ind[-1]} -eq 0 ]]; then
+        ind=()
+      fi
       if zstyle -T ":completion:${curcontext}:indexes" verbose; then
         list=()
         for i in "$ind[@]"; do


### PR DESCRIPTION
Small patch to ensure nonexistent indices are not offered as completion choices when subscripting empty arrays.

The problem:

```shell
# Clean zsh environment
$ env -i TERM=${TERM} TERMINFO=${TERMINFO} zsh -f
$ zmodload -i zsh/complist zsh/zle zsh/zutil
$ autoload -Uz compinit; compinit -D
$ zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters

# Example arrays
$ typeset -a arrfoo=(wheeler jump routine) arrbar=()

$ echo ${arrfoo[        # <TAB> produces expected completion options
1 -- wheeler  2 -- jump     3 -- routine

$ echo ${arrbar[        # <TAB> completes to [0] and [1] despite being empty
1  0
```

In the above, `arrbar` is empty and thus should not have any indices as completion choices. After applying the attached patch, we get the expected results:

```shell
# Clean zsh environment
$ env -i TERM=${TERM} TERMINFO=${TERMINFO} dist/bin/zsh-5.9.0.1-dev -f
$ zmodload -i zsh/complist zsh/zle zsh/zutil
$ autoload -Uz compinit; compinit -D
$ zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters

# Example arrays
$ typeset -a arrfoo=(wheeler jump routine) arrbar=()

$ echo ${arrfoo[        # <TAB> produces expected completion options
1 -- wheeler  2 -- jump     3 -- routine

$ echo ${arrbar[        # <TAB> instead completes to parameters as expected
zsh: do you wish to see all 148 possibilities (25 lines)?
```

Please let me know if there is any changes you'd like to see. I also sent the patch to zsh-workers@zsh.org: https://zsh.org/workers/53449