### PR TITLE
fix(build): fix builds with interactive manpagers

### DIFF
--- a/Util/helpfiles
+++ b/Util/helpfiles
@@ -57,7 +57,7 @@ $coltmp = $destdir . '/' . $coltmpbase;
 $args = "./$manfile >$mantmp";
 unlink($mantmp);
 &Info('attempting man ', $args);
-if(system('man ' . $args) || !(-s $mantmp)) {
+if(system('MANPAGER=cat man ' . $args) || !(-s $mantmp)) {
     unlink($mantmp);
     &Info('attempting nroff -man ', $args);
     if(system('nroff -man ' . $args) || !(-s $mantmp)) {


### PR DESCRIPTION

Summary:
The `MANPAGER` on my machine is `nvim`.  When running the `man` stage of the build, the build would freeze without giving any feedback.  This commit manually sets the manpager to the noninteractive `cat`.  This fixes the build.

Test Plan:
- Run `MANPAGER="nvim +Man!" make`
before: build would hang at `attempting man`
now: build completes successfully
