### PR TITLE
completion: darwin/_networksetup: fix socks flags

### DIFF
--- a/Completion/Darwin/Command/_networksetup
+++ b/Completion/Darwin/Command/_networksetup
@@ -183,7 +183,7 @@ _networksetup() {
   proxies=(
     ftp FTP
     gopher Gopher
-    socks SOCKS
+    socksfirewall SOCKS
     secureweb HTTPS
     streaming RTSP
     web HTTP


### PR DESCRIPTION
The flags are like `-getsocksfirewallproxy` (at least in newer versions of macos) instead of `-getsocksproxy` (which was previously set up in the completion script.

Tested on macos 15.5. 

```
$ networksetup -version
networksetup, Version 1.8.4
Copyright 2002-2020 Apple Inc. All rights reserved.
```