### PR TITLE
update completion: _install

### DIFF
--- a/Completion/Unix/Command/_install
+++ b/Completion/Unix/Command/_install
@@ -46,10 +46,12 @@ else
   )
   [[ $OSTYPE == dragonfly* ]] && args+=(
     '!-D+[no effect (compatibility with NetBSD)]: :_directories'
-    '-L+[use user/group database files from specified directory]: :_directories'
-    '-l[fall back to system files if user/group not found in -L directory]'
+    '-M[disable use of mmap(2)]'
+    '-S[use temporary files to perform safe copy]'
   )
-  [[ $OSTYPE == netbsd* ]] && args+=(
+  [[ $OSTYPE == netbsd* ]] && args=(
+    # NetBSD has no -C
+    ${args##((#s)|*\))(\*|)-C*}
     '-a+[specify shell command to run on files after install]:shell command'
     '-r[use temporary files to perform safe copy]'
     '-S+[specify arguments to pass to strip program]:arguments to strip program'
@@ -61,23 +63,23 @@ else
   [[ $OSTYPE == openbsd* ]] && args+=(
     '-D[create all leading destination path components]'
     '-F[flush installed file contents to disk]'
+    '!-S[no effect (supported for compatibility)]'
   )
-  [[ $OSTYPE == (darwin|dragonfly)* ]] && args+=(
-    '-M[disable use of mmap(2)]'
-  )
-  [[ $OSTYPE == (dragonfly|freebsd|netbsd)* ]] && args+=(
+  [[ $OSTYPE == (darwin|dragonfly|freebsd|netbsd)* ]] && args+=(
     '(-C -c --compare)-l+[link files (rather than copy) using specified method]: :->linkflags'
-    '+N+[use user/group database files from specified directory]: :_directories'
     '-U[indicate that install is unprivileged]'
   )
-  [[ $OSTYPE == (freebsd|netbsd)* ]] && args+=(
+  [[ $OSTYPE == (dragonfly|freebsd|netbsd)* ]] && args+=(
+    '-N+[use user/group database files from specified directory]: :_directories'
+  )
+  [[ $OSTYPE == (darwin|freebsd|netbsd)* ]] && args+=(
     '-D+[specify destination directory used for metadata log]: :_directories'
     '-h+[store digest in metadata log using specified method]: :->digests'
     '-M+[log mtree(8) metadata for installed files to specified file]:metadata log file:_files'
     '-T+[specify mtree(8) tags to store in metadata log]:mtree(8) tags'
   )
-  [[ $OSTYPE == netbsd* ]] || args+=(
-    '-S[use temporary files to perform safe copy]'
+  [[ $OSTYPE == (darwin|freebsd)* ]] && args+=(
+    '-S[flush each file to disk after copying]'
   )
 fi
 
@@ -95,7 +97,8 @@ case $state in
     _describe -t controls 'version control method' tmp && ret=0
     ;;
   digests)
-    tmp=( none md5 rmd160 sha1 sha256 sha512 )
+    tmp=( none sha1 sha256 sha512 )
+    [[ $OSTYPE == (free|net)bsd* ]] && tmp+=( md5 rmd160 )
     [[ $OSTYPE == netbsd* ]] && tmp+=( sha384 )
     _values 'digest method' $tmp && ret=0
     ;;


### PR DESCRIPTION
current to:
DragonFly 6.4.2
FreeBSD	14.3
NetBSD 10.1
OpenBSD 7.7
macOS 15.6.1

- -S[temp file] removed except for DragonFly; all other BSDs have removed this flag, and I can't find a commercial Unix that supports it
- -S[flush] replaces old -S opt on Darwin, FreeBSD
- -S disabled on OpenBSD which still supports it as a noop/compat option

- corrected +N flag to -N

- remove -C for NetBSD, it appears that this was never supported

- several other updates (mostly Net/Free flags added to Darwin/DragonFly)