### PR TITLE
Completion fortune databases

### DIFF
--- a/Completion/Unix/Command/_fortune
+++ b/Completion/Unix/Command/_fortune
@@ -12,4 +12,4 @@ _arguments \
   '-s[short apothegms only]' \
   '-i[ignore case for -m patterns]' \
   '-w[wait before termination for a time based on msg length]' \
-  '*:databases'
+  '*:fortune db:_files -W /usr/share/games/fortune(|s) -g "*(.:r)"'


### PR DESCRIPTION
hey @okapia 

in reference to https://github.com/zsh-users/zsh/pull/131#issuecomment-3439244707

> One exception is the fortune completion. On my system, the database is `/usr/share/games/fortune` so singular for the final path component and you would need to exclude `.dat` files. `compadd` should suffice - it rarely makes sense to use `_values` with generated values. Could you perhaps verify the fortune command you use. The completion can perhaps try multiple paths. It might be simpler if you do a fresh PR for any further fixups.

i removed the `-S` and hope that `.../fortune(|s) ..` is ok so. with a simple `.../fortunes? ...` it didn't work.

FYI, this is how it looks here on debian

```
% dpkg -S /usr/share/games/fortunes/
fortune-anarchism, fortunes-min, fortunes, fortunes-bofh-excuses: /usr/share/games/fortunes
% ls /usr/share/games/fortunes
anarchism      ascii-art.u8      cookie       definitions.dat  drugs.u8       food          goedel.dat     kids.u8       linux            literature.dat  magic.u8       miscellaneous      paradoxum.dat  perl.u8         politics       riddles.dat      songs-poems.u8  tao               wisdom.dat  zippy.u8
anarchism.dat  bofh-excuses      cookie.dat   definitions.u8   education      food.dat      goedel.u8      knghtbrd      linux.dat        literature.u8   medicine       miscellaneous.dat  paradoxum.u8   pets            politics.dat   riddles.u8       sports          tao.dat           wisdom.u8
art            bofh-excuses.dat  cookie.u8    disclaimer       education.dat  food.u8       humorists      knghtbrd.dat  linux.u8         love            medicine.dat   miscellaneous.u8   people         pets.dat        politics.u8    science          sports.dat      tao.u8            work
art.dat        bofh-excuses.u8   debian       disclaimer.dat   education.u8   fortunes      humorists.dat  knghtbrd.u8   linuxcookie      love.dat        medicine.u8    news               people.dat     pets.u8         pratchett      science.dat      sports.u8       translate-me      work.dat
art.u8         computers         debian.dat   disclaimer.u8    ethnic         fortunes.dat  humorists.u8   law           linuxcookie.dat  love.u8         men-women      news.dat           people.u8      platitudes      pratchett.dat  science.u8       startrek        translate-me.dat  work.u8
ascii-art      computers.dat     debian.u8    drugs            ethnic.dat     fortunes.u8   kids           law.dat       linuxcookie.u8   magic           men-women.dat  news.u8            perl           platitudes.dat  pratchett.u8   songs-poems      startrek.dat    translate-me.u8   zippy
ascii-art.dat  computers.u8      definitions  drugs.dat        ethnic.u8      goedel        kids.dat       law.u8        literature       magic.dat       men-women.u8   paradoxum          perl.dat       platitudes.u8   riddles        songs-poems.dat  startrek.u8     wisdom            zippy.dat
% whence -f _fortune |sed "s%' '%'\n\t'%g"
_fortune () {
        _arguments '-a[choose from all lists of maxims, both offensive and not]'
        '-c[show the cookie file from which the fortune came]'
        '-e[consider all fortune files to be of equal size]'
        '-f[print out the list of files which would be searched]'
        '-l[long dictums only]'
        '-m[print all matches to regex]:BRE'
        '-n[set longest length to be short]:length'
        '-o[choose only from potentially offensive aphorisms]'
        '-s[short apothegms only]'
        '-i[ignore case for -m patterns]'
        '-w[wait before termination for a time based on msg length]'
        '*:fortune db:_files -W /usr/share/games/fortune(|s) -g "*(.:r)"'
}
% fortune anarchism
completing fortune db
anarchism      bofh-excuses   debian         drugs          food           humorists      law            literature     medicine       news           perl           politics       science        startrek       wisdom
art            computers      definitions    education      fortunes       kids           linux          love           men-women      paradoxum      pets           pratchett      songs-poems    tao            work
ascii-art      cookie         disclaimer     ethnic         goedel         knghtbrd       linuxcookie    magic          miscellaneous  people         platitudes     riddles        sports         translate-me   zippy
