### PR TITLE
completion: shutdown: suggest 'now' for time argument

### DIFF
--- a/Completion/Unix/Command/_shutdown
+++ b/Completion/Unix/Command/_shutdown
@@ -1,9 +1,10 @@
 #compdef shutdown
 
 local -a args
+local state
 
 if [[ -d /etc/systemd ]]; then
-  _arguments \
+  _arguments -C \
     '--help[display usage information]' \
     '(-H --halt)'{-H,--halt}'[halt the machine]' \
     '(-P --poweroff -h)'{-P,--poweroff,-h}'[power-off the machine (default)]' \
@@ -11,8 +12,19 @@ if [[ -d /etc/systemd ]]; then
     "(--no-wall)-k[don't shutdown, just write wall message]" \
     "(-k)--no-wall[don't send a wall message]" \
     '-c[cancel pending shutdown]' \
-    '1: :_guard "^-*" "time (now/hh\:mm/+mins)"' \
+    '1:time:->time' \
     '*:warning message'
+
+  case $state in
+    time)
+      _values -s ' ' 'shutdown time' \
+        'now[shutdown immediately]' \
+        '+1[shutdown in 1 minute]' \
+        '+5[shutdown in 5 minutes]' \
+        '+10[shutdown in 10 minutes]'
+      ;;
+  esac
+
   return
 fi
 
@@ -23,7 +35,7 @@ case $OSTYPE in
       '-r[reboot the system]'
       '-k[kick everybody off]'
       '-n[prevent file system cache from being flushed]'
-      '1: :_guard "^-*" "time (now/hh\:mm/+mins)"'
+      '1:time:->time'
       '*:warning message'
     )
   ;|
@@ -74,4 +86,14 @@ case $OSTYPE in
   ;;
 esac
 
-_arguments $args
+_arguments -C $args
+
+case $state in
+  time)
+    _values -s ' ' 'shutdown time' \
+      'now[shutdown immediately]' \
+      '+1[shutdown in 1 minute]' \
+      '+5[shutdown in 5 minutes]' \
+      '+10[shutdown in 10 minutes]'
+  ;;
+esac


### PR DESCRIPTION
Current shutdown completion uses `_guard` for the time argument:

    '1: :_guard "^-*" "time (now/hh:mm/+mins)"'

`_guard` only validates the argument but does not provide completion
candidates. As a result, usage such as:

    shutdown n<TAB>

does not complete to `shutdown now`.

This patch introduces a completion state for the time argument and
adds a suggestion for the commonly used value `now`. The completion
still allows arbitrary values such as `+mins` and `hh:mm`.