### PR TITLE
_apt add history commands

### DIFF
--- a/Completion/Debian/Command/_apt
+++ b/Completion/Debian/Command/_apt
@@ -468,7 +468,9 @@ _apt-cmd () {
     /$'full-upgrade\0'/ \| \
     /$'dist-upgrade\0'/ \| \
     /$'edit-sources\0'/ /$'[^\0]#\0'/ ': ::_apt_sources' \# \| \
-    /"[]"/ ':argument-1::compadd "$expl_action[@]" list search showsrc show depends rdepends policy update install reinstall download source build-dep remove upgrade full-upgrade dist-upgrade edit-sources autoclean changelog autopurge autoremove purge why why-not'
+    /$'history-list\0'/ \| \
+    /$'(history-(info|redo|undo|rollback))\0'/ /$'[^\0]#\0'/ ': ::_apt_history_ids' \# \| \
+    /"[]"/ ':argument-1::compadd "$expl_action[@]" list search showsrc show depends rdepends policy update install reinstall download source build-dep remove upgrade full-upgrade dist-upgrade edit-sources autoclean changelog autopurge autoremove purge why why-not history-list history-info history-redo history-undo history-rollback'
 
   _apt-cmd () {
     local expl_action expl_packages subcmd
@@ -791,6 +793,12 @@ _apt_snapshot_dates() {
     done
   }
   _wanted list expl 'wayback date (yyyymmdd[ThhmmssZ])' compadd -- $dates
+}
+
+_apt_history_ids() {
+  local -a expl historyids
+  historyids=( ${${${(f)"$(_call_program history-ids apt history-list)"}:#ID*}%% *} )
+  _wanted history-ids expl 'history id' compadd -o numeric,reverse -a historyids
 }
 
 _apt "$@"


### PR DESCRIPTION
Extend apt completion with new commands (apt>=3.1.6): history-list, history-info, history-redo, history-undo and history-rollback