### PR TITLE
fix darcs completion script

### DIFF
--- a/Completion/Unix/Command/_darcs
+++ b/Completion/Unix/Command/_darcs
@@ -31,8 +31,9 @@ else
         ;;
     # Otherwise, let's ask darcs for all possible options
     *)
-      _wanted args expl 'arg for darcs command' \
-        compadd -- $( darcs ${words[2]} --list-option )
+        local -a darcs_opts
+        darcs_opts=( ${(@)${(f)"$(darcs ${words[2]} --list-options)"}//;/:} )
+        _describe -t args 'arg for darcs command' darcs_opts
       ;;
   esac
 fi


### PR DESCRIPTION
`darcs <something> --list-options`  provides some of the available options in the format <option>;<docs> . the former script dumps the full line, which is quite incovenient and you have to delte the pasted doc if you select an option. This fix replace the ';' with a ':' to display the docs properly and select only the option.