### PR TITLE
Add Windows portable zsh packaging helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ Src/Zle/zle_widget.h
 Test/*.tmp
 /.project
 .DS_Store
+
+build
+Main

--- a/helper/README-win.md
+++ b/helper/README-win.md
@@ -1,0 +1,142 @@
+# Building zsh on Windows
+
+zsh is a POSIX shell and cannot be built with MSVC alone; it needs the MSYS2
+(Cygwin-derived) POSIX runtime and toolchain. These scripts automate that.
+
+## Prerequisites
+
+- [scoop](https://scoop.sh) and/or [winget](https://learn.microsoft.com/windows/package-manager/winget/)
+  available on PATH. `install_build_tool.sh` will install scoop via winget if
+  it's missing.
+- Run scripts from Git Bash or another POSIX shell (not PowerShell/cmd).
+
+## Usage
+
+```sh
+sh helper/install_build_tool.sh   # one-time: installs MSYS2 + gcc/make/autoconf/automake/ncurses-devel
+sh helper/compile.sh              # builds zsh into ./build
+sh helper/scoop_install.sh        # optional: install the result as a scoop app with a `zsh` shim
+```
+
+### install_build_tool.sh
+
+Installs, in order:
+
+1. **scoop** (via winget, if not already present)
+2. **MSYS2** (via scoop, falling back to winget) at
+   `~/scoop/apps/msys2/current` (or `C:\msys64` if installed via winget)
+3. Build tools inside MSYS2 via `pacman`: `gcc`, `make`, `autoconf`,
+   `automake`, `ncurses-devel`
+
+These are the plain `msys/*` packages (POSIX runtime), not the
+`mingw-w64-*` cross-toolchain packages — zsh's autotools build expects a
+Cygwin-like environment.
+
+### compile.sh
+
+Builds zsh out-of-tree so the source directory stays clean:
+
+1. Runs `Util/preconfig` (autoconf) in the source tree if `configure` doesn't
+   exist yet.
+2. Runs `configure` and `make -j$(nproc)` **inside `build/`** (VPATH build),
+   not in the source tree.
+3. Assembles a **portable runtime in `build/bin`**: `zsh.exe`, `zsh.cmd`,
+   `libzsh-*.dll`, all dynamic modules from `config.modules`, a bootstrap
+   `.zshenv` for the wrapper, MSYS2 runtime DLLs discovered via `ldd`,
+   `tput.exe`, and the MSYS2 terminfo database.
+4. Removes autotools-generated files from the source tree afterward
+   (`configure`, `config.h.in`, `autom4te.cache`, `stamp-h.in`, `META-FAQ`).
+5. Leaves `build/` in place — it is **not** cleaned up.
+
+**Build output**: `build/bin/zsh.cmd` is the supported portable entry point.
+It launches `build/bin/zsh.exe` after setting up the runtime environment.
+Intermediate build artifacts remain under `build/`.
+
+**CRLF guard**: if the source tree's line endings have been converted to
+CRLF (e.g. by `core.autocrlf=true`), the autotools build breaks. In that
+case the script detects the damaged `configure.ac` and instead builds from a
+clean detached git worktree at `../zsh-build`, leaving your source tree
+untouched. Fix `core.autocrlf` and restore LF endings to avoid this path.
+
+## Running the built binary
+
+`build/bin` is self-contained — the required MSYS2 DLLs sit next to
+`zsh.exe`, so it runs from Git Bash, cmd, or PowerShell without MSYS2 on
+`PATH`:
+
+```sh
+build/bin/zsh.cmd --version
+```
+
+Dynamic modules (`zsh/zle`, `zsh/complete`, ...) are compiled to look in
+`/usr/local/lib/zsh/<version>`, which won't exist outside MSYS2. Use the
+portable `zsh.cmd` wrapper so the packaged `.zshenv` can prepend `build/bin`
+to `module_path`, then restore your real `ZDOTDIR`:
+
+```sh
+build/bin/zsh.cmd
+```
+
+Do **not** run the bare `build/Src/zsh.exe` from Git Bash — it will fail
+with error 0xc0000135 because Git Bash doesn't ship the MSYS2 runtime DLLs
+(its own `msys-2.0.dll` is a different, incompatible build and it has no
+`msys-ncursesw6.dll`).
+
+The wrapper/bootstrap also:
+
+- sets `HOME` from Windows `%USERPROFILE%`, so `~/` resolves to your Windows
+  profile instead of a missing `/home/<user>` directory;
+- sets `TERMINFO` before zsh starts and packages `share/terminfo`, so `tput`
+  and terminals such as `xterm-256color` work;
+- prepends `build/bin` to `PATH`, so packaged helper tools such as `tput.exe`
+  are found;
+- sets the default interactive prompt to `username@current-path`;
+- binds both common Backspace sequences (`^?` and `^H`) in `main`, `emacs`,
+  and `viins` keymaps. If Backspace still behaves exactly like Tab, the
+  terminal is likely sending literal `^I`, which must be fixed in the
+  terminal profile/keybinding.
+
+Note: `make install` into the MSYS2 prefix currently fails at
+`install.modules` (a `rlimits` module link error against static libc on
+MSYS); use the portable `build/bin` layout instead.
+
+## Installing as a scoop app (scoop_install.sh)
+
+`sh helper/scoop_install.sh` packages `build/bin` and installs it through
+scoop, using the manifest in `bucket/zsh.json`:
+
+1. Zips `build/bin/*` to `build/release/zsh.zip` (with Windows' bsdtar —
+   PowerShell's `Compress-Archive` cannot read the MSYS2-built binaries).
+2. Regenerates `bucket/zsh.json` with the version, a `file:///` URL to the
+   zip, and its sha256 hash.
+3. Runs `scoop install bucket/zsh.json` (uninstalling any previous zsh
+   first), which:
+   - extracts the zip to `~/scoop/apps/zsh/<version>\` and links
+     `~/scoop/apps/zsh/current` to it — this is scoop's canonical location,
+     derived from the manifest filename and `version` field;
+   - creates `~/scoop/shims/zsh` and `~/scoop/shims/zsh.cmd` from the
+     manifest's `zsh.cmd` entry, so `zsh` works from any shell with scoop's
+     shims on `PATH`;
+   - uses the wrapper and packaged `.zshenv` to set `module_path`, `HOME`,
+     `TERMINFO`, prompt defaults, and Backspace bindings without relying on
+     the ignored `MODULE_PATH` environment variable.
+
+The installer clears Scoop's `zsh` download cache before reinstalling, because
+the local `file:///` zip is regenerated on each package run.
+
+To rebuild and reinstall after source changes:
+`sh helper/compile.sh && sh helper/scoop_install.sh`.
+To remove: `scoop uninstall zsh`.
+
+## Known non-fatal warnings
+
+During `make`, you may see:
+
+```
+sh: line 1: man: command not found
+sh: line 1: nroff: command not found
+```
+
+These only affect regeneration of `Doc/help.txt` (interactive `run-help`
+text) and don't fail the build. Install `man`/`groff` via pacman if you need
+that file regenerated.

--- a/helper/compile.sh
+++ b/helper/compile.sh
@@ -1,0 +1,220 @@
+#!/bin/sh
+# compile.sh - Build zsh on Windows using the MSYS2 toolchain.
+#
+# Prerequisite: sh helper/install_build_tool.sh
+#
+# Usage (from Git Bash or any POSIX shell):
+#   sh helper/compile.sh [source-dir]
+#
+# This is an out-of-tree (VPATH) build: all build output lands in <repo>/build
+# and is kept after the build. The resulting binary is build/Src/zsh.exe.
+# Generated autotools files in the source tree (configure, config.h.in,
+# autom4te.cache, ...) are removed once the build finishes, so the source
+# tree stays clean.
+#
+# The autotools build requires LF line endings. If the source tree has been
+# converted to CRLF (e.g. by core.autocrlf=true), this script builds from a
+# clean detached git worktree at ../zsh-build instead of the damaged tree.
+
+set -e
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+SRC="${1:-$REPO}"
+BUILD="$REPO/build"
+
+to_msys_path() {
+    case "$1" in
+        [A-Za-z]:/*|[A-Za-z]:\\*)
+            if command -v cygpath >/dev/null 2>&1; then
+                cygpath -u "$1"
+            else
+                drive=$(printf '%s' "$1" | sed 's#^\([A-Za-z]\):.*#\1#' | tr 'A-Z' 'a-z')
+                rest=$(printf '%s' "$1" | sed 's#^[A-Za-z]:[/\\]*##; s#\\#/#g')
+                printf '/%s/%s\n' "$drive" "$rest"
+            fi
+            ;;
+        *)
+            printf '%s\n' "$1"
+            ;;
+    esac
+}
+
+MSYS2_ROOT="$HOME/scoop/apps/msys2/current"
+[ -x "$MSYS2_ROOT/usr/bin/bash.exe" ] || MSYS2_ROOT="$(to_msys_path "$USERPROFILE")/scoop/apps/msys2/current"
+[ -x "$MSYS2_ROOT/usr/bin/bash.exe" ] || MSYS2_ROOT="/c/msys64"
+MSYS2_BASH="$MSYS2_ROOT/usr/bin/bash.exe"
+
+if [ ! -x "$MSYS2_BASH" ]; then
+    echo "error: MSYS2 not found; run helper/install_build_tool.sh first" >&2
+    exit 1
+fi
+
+# --- Guard against CRLF-damaged checkouts ----------------------------------
+if [ -f "$SRC/configure.ac" ] && grep -q "$(printf '\r')" "$SRC/configure.ac"; then
+    echo "==> Source tree has CRLF line endings; using clean worktree ../zsh-build"
+    WT="$SRC/../zsh-build"
+    if [ ! -d "$WT" ]; then
+        git -C "$SRC" worktree add --detach "$WT" HEAD
+    fi
+    SRC=$(cd "$WT" && pwd)
+fi
+
+SRC_MSYS=$(to_msys_path "$SRC")
+BUILD_MSYS=$(to_msys_path "$BUILD")
+
+echo "==> Source tree:  $SRC"
+echo "==> Build output: $BUILD"
+mkdir -p "$BUILD" 2>/dev/null || mkdir -p "$BUILD_MSYS"
+
+# --- preconfig, configure (in build/), make ---------------------------------
+"$MSYS2_BASH" -lc "
+    set -e
+    export PATH=/usr/bin:\$PATH
+    export TMPDIR='$BUILD_MSYS/tmp'
+    mkdir -p \"\$TMPDIR\"
+    cd '$SRC_MSYS'
+
+    # a leftover in-tree build breaks VPATH builds; clear it first
+    if [ -f config.status ]; then
+        echo '==> Removing leftover in-tree build (make distclean)...'
+        make distclean >/dev/null 2>&1 || true
+    fi
+
+    if [ ! -f configure ]; then
+        echo '==> Generating configure (Util/preconfig)...'
+        ./Util/preconfig
+    fi
+
+    cd '$BUILD_MSYS'
+    # re-run configure serially if it was regenerated, otherwise parallel
+    # sub-makes race to reconfigure and corrupt each other's conftest files
+    if [ ! -f config.status ] || [ '$SRC_MSYS/configure' -nt config.status ]; then
+        echo '==> Running configure (out-of-tree)...'
+        # config.guess reports mingw32, not cygwin, so configure picks bare
+        # ld for module linking; modern binutils then exports no symbols and
+        # configure silently disables dynamic modules. Preset the link
+        # command the cygwin branch would use.
+        DLLD=gcc DLLDFLAGS='-shared -Wl,--export-all-symbols' \
+            '$SRC_MSYS/configure' --prefix=/usr/local
+    fi
+
+    echo '==> Running make...'
+    make -j\$(nproc)
+
+    # --- Assemble a portable runtime in build/bin ---------------------------
+    # zsh.exe + libzsh + loadable modules + the MSYS2 runtime DLLs they need,
+    # so the result runs from any shell (Git Bash, cmd, ...) without MSYS2
+    # on PATH. Modules go in bin/zsh/ because module 'zsh/foo' is looked up
+    # as <module_path>/zsh/foo.dll.
+    echo '==> Assembling portable runtime in build/bin...'
+    cd '$BUILD_MSYS'
+    rm -rf bin
+    mkdir -p bin
+    cp Src/zsh.exe Src/libzsh-*.dll bin/
+
+    sed -n 's/^name=\([^ ]*\).* modfile=\([^ ]*\).* link=dynamic .*/\1 \2/p' config.modules \\
+        | while read -r modname modfile; do
+            src=\"\${modfile%.mdd}.dll\"
+            dll=\"\${modfile##*/}\"
+            dll=\"\${dll%.mdd}.dll\"
+            dest=\"bin/\$modname.dll\"
+            if [ -f \"\$src\" ]; then
+                mkdir -p \"\$(dirname \"\$dest\")\"
+                cp \"\$src\" \"\$dest\"
+            else
+                echo \"warning: expected module not found: \$src\" >&2
+            fi
+        done
+
+    { ldd Src/zsh.exe; find Src -name '*.dll' -exec ldd {} +; } 2>/dev/null \\
+        | awk '/=> \/usr\/bin\/msys-/ { print \$3 }' | sort -u \\
+        | while read -r dll; do cp \"\$dll\" bin/; done
+
+    if command -v tput.exe >/dev/null 2>&1; then
+        cp \"\$(command -v tput.exe)\" bin/
+    fi
+    if [ -d /usr/share/terminfo ]; then
+        mkdir -p bin/share
+        cp -R /usr/share/terminfo bin/share/
+    fi
+"
+
+# --- Portable launcher + zsh bootstrap --------------------------------------
+# Written here (outer script), not inside the MSYS2 -lc "..." string above:
+# these heredocs contain literal double quotes, which would otherwise close
+# that outer double-quoted string early and mangle everything after it.
+cat > "$BUILD/bin/zsh.cmd" <<'EOF_CMD'
+@echo off
+set "ZSH_PORTABLE_DIR=%~dp0"
+set "ZSH_WIN_HOME=%USERPROFILE%"
+set "ZSH_TERMINFO_DIR=%ZSH_PORTABLE_DIR:\=/%share/terminfo"
+set "ZSH_TERMINFO_DRIVE=%ZSH_TERMINFO_DIR:~0,1%"
+set "ZSH_TERMINFO_PATH=%ZSH_TERMINFO_DIR:~2%"
+set "TERMINFO=/cygdrive/%ZSH_TERMINFO_DRIVE%%ZSH_TERMINFO_PATH%"
+set "PATH=%ZSH_PORTABLE_DIR%;%PATH%"
+if defined ZDOTDIR (
+    set "ZSH_ORIG_ZDOTDIR=%ZDOTDIR%"
+) else (
+    set "ZSH_ORIG_ZDOTDIR=%USERPROFILE%"
+)
+set "ZDOTDIR=%ZSH_PORTABLE_DIR%"
+"%ZSH_PORTABLE_DIR%zsh.exe" %*
+EOF_CMD
+
+cat > "$BUILD/bin/.zshenv" <<'EOF_ZSHENV'
+zsh_portable_dir=${ZSH_PORTABLE_DIR:-}
+if [[ -n $zsh_portable_dir ]]; then
+  zsh_portable_dir=${zsh_portable_dir//\\//}
+  zsh_portable_dir=${zsh_portable_dir%/}
+  if [[ $zsh_portable_dir == [A-Za-z]:/* ]]; then
+    zsh_portable_dir="/cygdrive/${(L)zsh_portable_dir[1]}/${zsh_portable_dir[4,-1]}"
+  fi
+  module_path=("$zsh_portable_dir" $module_path)
+  TERMINFO="$zsh_portable_dir/share/terminfo"
+  export TERMINFO
+fi
+if [[ -n ${ZSH_WIN_HOME:-} ]]; then
+  HOME=${ZSH_WIN_HOME//\\//}
+  export HOME
+fi
+if [[ -o interactive ]]; then
+  PROMPT="%n@%~%# "
+  zsh_portable_fix_keys() {
+    local zsh_portable_keymap
+    for zsh_portable_keymap in main emacs viins; do
+      bindkey -M "$zsh_portable_keymap" "^?" backward-delete-char 2>/dev/null
+      bindkey -M "$zsh_portable_keymap" "^H" backward-delete-char 2>/dev/null
+    done
+    stty erase "^?" 2>/dev/null || stty erase "^H" 2>/dev/null
+  }
+  precmd_functions=(${precmd_functions:#zsh_portable_fix_keys} zsh_portable_fix_keys)
+fi
+
+if [[ -n ${ZSH_ORIG_ZDOTDIR:-} ]]; then
+  zsh_orig_zdotdir=${ZSH_ORIG_ZDOTDIR//\\//}
+  ZDOTDIR=$zsh_orig_zdotdir
+  export ZDOTDIR
+  if [[ $ZDOTDIR != $zsh_portable_dir && -r $ZDOTDIR/.zshenv ]]; then
+    source $ZDOTDIR/.zshenv
+  fi
+  unset ZSH_ORIG_ZDOTDIR ZSH_PORTABLE_DIR ZSH_WIN_HOME zsh_portable_dir zsh_orig_zdotdir
+fi
+EOF_ZSHENV
+
+# --- Stamp the build: zsh version + source commit ---------------------------
+{
+    "$BUILD/bin/zsh.exe" --version
+    git -C "$SRC" log -1 --format='%H'
+} > "$BUILD/bin/version.txt"
+echo "==> version.txt:"
+cat "$BUILD/bin/version.txt"
+
+# --- Clean generated files out of the source tree; keep build/ --------------
+echo "==> Cleaning generated files from source tree..."
+rm -rf "$SRC/autom4te.cache"
+rm -f "$SRC/configure" "$SRC/config.h.in" "$SRC/stamp-h.in" "$SRC/META-FAQ"
+
+echo "==> Build complete. Output kept in: $BUILD"
+echo "==> Portable runtime: $BUILD/bin (zsh.cmd, zsh.exe, required DLLs, modules)"
+"$BUILD/bin/zsh.exe" --version
+echo "==> For dynamic modules (zle etc.) outside MSYS2, run $BUILD/bin/zsh.cmd"

--- a/helper/install_build_tool.sh
+++ b/helper/install_build_tool.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# install_build_tool.sh - Install the toolchain needed to build zsh on Windows.
+#
+# zsh is a POSIX shell and cannot be built with MSVC/MinGW alone; it needs the
+# MSYS2 (Cygwin-derived) POSIX runtime. This script installs:
+#   1. scoop        (via winget, if missing)
+#   2. MSYS2        (via scoop, with winget fallback)
+#   3. build tools  (gcc, make, autoconf, automake, ncurses-devel via pacman)
+#
+# Run from Git Bash or any POSIX shell on Windows:
+#   sh helper/install_build_tool.sh
+
+set -e
+
+# --- 1. scoop -------------------------------------------------------------
+if ! command -v scoop >/dev/null 2>&1; then
+    echo "==> Installing scoop via winget..."
+    winget install --id ScoopInstaller.Scoop -e --accept-source-agreements \
+        --accept-package-agreements
+else
+    echo "==> scoop already installed"
+fi
+
+# --- 2. MSYS2 -------------------------------------------------------------
+MSYS2_ROOT="$HOME/scoop/apps/msys2/current"
+if [ ! -x "$MSYS2_ROOT/usr/bin/bash.exe" ]; then
+    echo "==> Installing MSYS2..."
+    if command -v scoop >/dev/null 2>&1; then
+        scoop install msys2
+    else
+        winget install --id MSYS2.MSYS2 -e --accept-source-agreements \
+            --accept-package-agreements
+        MSYS2_ROOT="/c/msys64"
+    fi
+else
+    echo "==> MSYS2 already installed at $MSYS2_ROOT"
+fi
+
+# --- 3. First-run setup + pacman keyring ------------------------------------
+# A fresh MSYS2 install must be started once to create /etc, HOME, and the
+# pacman keyring; without it pacman fails with "Public keyring not found" /
+# "keyring is not writable" / PGP signature errors. pacman-key is a script
+# inside MSYS2, so it must run via MSYS2's bash, not PowerShell/cmd.
+"$MSYS2_ROOT/usr/bin/bash.exe" -lc 'true'
+if [ ! -d "$MSYS2_ROOT/etc/pacman.d/gnupg" ]; then
+    echo "==> Initializing pacman keyring (first run)..."
+    "$MSYS2_ROOT/usr/bin/bash.exe" -lc \
+        'pacman-key --init && pacman-key --populate msys2'
+fi
+
+# --- 4. Build tools inside MSYS2 -------------------------------------------
+# NOTE: use the plain 'msys' packages (POSIX runtime), NOT mingw-w64-* ones.
+echo "==> Installing gcc, make, autoconf, automake, ncurses-devel..."
+"$MSYS2_ROOT/usr/bin/pacman.exe" -Sy --noconfirm --needed \
+    gcc make autoconf automake ncurses-devel
+
+echo "==> Done. Toolchain check:"
+"$MSYS2_ROOT/usr/bin/bash.exe" -lc \
+    'export PATH=/usr/bin:$PATH; gcc --version | head -1; make --version | head -1; autoconf --version | head -1'
+
+echo "==> Next step: sh helper/compile.sh"

--- a/helper/scoop_install.sh
+++ b/helper/scoop_install.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# scoop_install.sh - Package the portable build/bin runtime and install it
+# via scoop, so zsh lands in scoop's standard app location with a shim.
+#
+# Prerequisite: sh helper/compile.sh  (produces build/bin)
+#
+# Usage (from Git Bash or any POSIX shell):
+#   sh helper/scoop_install.sh
+#
+# What it does:
+#   1. Zips build/bin/*  ->  build/zsh-<version>-x64.zip
+#   2. Regenerates bucket/zsh.json with the version and sha256 hash
+#      (file:/// url pointing at the zip)
+#   3. scoop install bucket/zsh.json, which:
+#        - extracts to  ~/scoop/apps/zsh/<version>\   (+ 'current' junction)
+#        - creates the shim  ~/scoop/shims/zsh.exe    (from zsh.cmd)
+#        - uses the packaged .zshenv bootstrap so zsh finds dynamic modules
+
+set -e
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+BUILD="$REPO/build"
+BUCKET="$REPO/bucket"
+
+to_windows_path() {
+    case "$1" in
+        [A-Za-z]:/*)
+            printf '%s\n' "$1"
+            ;;
+        [A-Za-z]:\\*)
+            printf '%s\n' "$1" | sed 's#\\#/#g'
+            ;;
+        *)
+            if command -v cygpath >/dev/null 2>&1; then
+                cygpath -m "$1"
+            else
+                case "$1" in
+                    /[A-Za-z]/*)
+                        drive=$(printf '%s' "$1" | sed 's#^/\([A-Za-z]\)/.*#\1#' | tr 'a-z' 'A-Z')
+                        rest=$(printf '%s' "$1" | sed 's#^/[A-Za-z]/##')
+                        printf '%s:/%s\n' "$drive" "$rest"
+                        ;;
+                    *)
+                        printf '%s\n' "$1"
+                        ;;
+                esac
+            fi
+            ;;
+    esac
+}
+
+find_windows_tar() {
+    for tar in \
+        /c/Windows/System32/tar.exe \
+        C:/Windows/System32/tar.exe \
+        /mnt/c/Windows/System32/tar.exe
+    do
+        if [ -x "$tar" ]; then
+            printf '%s\n' "$tar"
+            return 0
+        fi
+    done
+
+    if command -v tar.exe >/dev/null 2>&1; then
+        command -v tar.exe
+        return 0
+    fi
+
+    return 1
+}
+
+if [ ! -x "$BUILD/bin/zsh.exe" ]; then
+    echo "error: $BUILD/bin/zsh.exe not found; run helper/compile.sh first" >&2
+    exit 1
+fi
+if [ ! -f "$BUILD/bin/zsh.cmd" ] || [ ! -f "$BUILD/bin/zsh/zle.dll" ]; then
+    echo "error: build/bin is missing zsh.cmd or zsh/zle.dll; rerun helper/compile.sh" >&2
+    exit 1
+fi
+command -v scoop >/dev/null 2>&1 || {
+    echo "error: scoop not found; run helper/install_build_tool.sh first" >&2
+    exit 1
+}
+
+VERSION=$("$BUILD/bin/zsh.exe" --version | awk '{print $2}')
+RELEASE="$BUILD/release"
+ZIP="$RELEASE/zsh.zip"
+REPO_WIN=$(to_windows_path "$REPO")   # Windows-style path (C:/...)
+TAR_EXE=$(find_windows_tar) || {
+    echo "error: Windows tar.exe not found; expected it under C:/Windows/System32" >&2
+    exit 1
+}
+
+# Public download URL for scoop users: the git origin remote, develop branch.
+# (Requires build/release/zsh.zip to be committed and pushed on develop.)
+ORIGIN=$(git -C "$REPO" remote get-url origin | sed -e 's/\.git$//')
+PUBLIC_URL=$(printf '%s' "$ORIGIN" \
+    | sed -e 's#github\.com#raw.githubusercontent.com#')/develop/build/release/zsh.zip
+
+# --- 1. Zip the portable runtime --------------------------------------------
+# Windows' bsdtar is used because PowerShell's Compress-Archive cannot read
+# the MSYS2-built binaries.
+echo "==> Packaging build/bin -> build/release/zsh.zip"
+mkdir -p "$RELEASE"
+rm -f "$ZIP"
+"$TAR_EXE" -a -cf "$REPO_WIN/build/release/zsh.zip" \
+    -C "$REPO_WIN/build/bin" .
+[ -f "$ZIP" ] || { echo "error: zip creation failed" >&2; exit 1; }
+
+HASH=$(sha256sum "$ZIP" | awk '{print $1}')
+[ -n "$HASH" ] || { echo "error: could not hash zip" >&2; exit 1; }
+echo "==> sha256: $HASH"
+
+# --- 2. Regenerate the scoop manifest ----------------------------------------
+mkdir -p "$BUCKET"
+cat > "$BUCKET/zsh.json" <<EOF
+{
+    "version": "$VERSION",
+    "description": "Zsh shell built from source with the MSYS2 toolchain (portable runtime)",
+    "homepage": "https://www.zsh.org",
+    "license": "Zsh (MIT-like)",
+    "architecture": {
+        "64bit": {
+            "url": "$PUBLIC_URL",
+            "hash": "$HASH"
+        }
+    },
+    "bin": [
+        [
+            "zsh.cmd",
+            "zsh"
+        ]
+    ],
+    "notes": "zsh built from source with MSYS2; zip served from the develop branch of $ORIGIN."
+}
+EOF
+echo "==> Wrote $BUCKET/zsh.json (url: $PUBLIC_URL)"
+
+# A local-file variant of the manifest, so the install can be tested before
+# the zip is committed and pushed to origin/develop.
+mkdir -p "$BUILD/local-manifest"
+sed "s#\"url\": \".*\"#\"url\": \"file:///$REPO_WIN/build/release/zsh.zip\"#" \
+    "$BUCKET/zsh.json" > "$BUILD/local-manifest/zsh.json"
+
+# --- 3. Install through scoop ------------------------------------------------
+if scoop list zsh 2>/dev/null | grep -q '^zsh '; then
+    echo "==> Removing previously installed zsh..."
+    scoop uninstall zsh
+fi
+echo "==> Clearing scoop download cache for zsh..."
+scoop cache rm zsh 2>/dev/null || true
+echo "==> Installing via scoop (from local zip)..."
+scoop install "$REPO_WIN/build/local-manifest/zsh.json"
+
+# --- 4. Verify ---------------------------------------------------------------
+echo "==> Installed. Shim check:"
+SHIM="$HOME/scoop/shims/zsh"
+if [ ! -x "$SHIM" ] && [ -x "$HOME/scoop/shims/zsh.cmd" ]; then
+    SHIM="$HOME/scoop/shims/zsh.cmd"
+fi
+"$SHIM" --version
+echo "==> App dir: $HOME/scoop/apps/zsh/current"
+echo "==> zsh.cmd bootstraps module_path for dynamic modules; run: zsh"


### PR DESCRIPTION
Adds helper scripts and documentation for building and packaging a portable Windows zsh runtime with MSYS2 and Scoop.

Summary:
- add MSYS2 toolchain install, compile, and Scoop packaging helpers\n- assemble a portable runtime with dynamic modules, runtime DLLs, tput, and terminfo
- generate a zsh.cmd wrapper and bootstrap .zshenv for module_path, HOME, TERMINFO, prompt defaults, and Backspace bindings
- add a Scoop manifest for the packaged runtime

Verification:
- helper scripts were syntax-checked with bash
- wrapper smoke checks verified zsh startup, tput/terminfo lookup, and module loading locally and also tested with scoop install
```
scoop bucket add raliclo https://github.com/raliclo/zsh.git
scoop install zsh
```